### PR TITLE
Fix implementation of 8-bit pixmap transformation

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -486,10 +486,10 @@ static void twin_pixmap_read_xform_8(twin_xform_t *xform, twin_coord_t line)
         _get_pix_8(pts[0], pix, sx, sy);
         _get_pix_8(pts[1], pix, sx + TWIN_FIXED_ONE, sy);
         _get_pix_8(pts[2], pix, sx, sy + TWIN_FIXED_ONE);
-        _get_pix_8(pts[3], pix, sx, sy + TWIN_FIXED_ONE);
+        _get_pix_8(pts[3], pix, sx + TWIN_FIXED_ONE, sy + TWIN_FIXED_ONE);
         wx = sx & 0xffff;
         wy = sy & 0xffff;
-        *(dst++) = _pix_saucemix(pts[0], pts[1], pts[2], pts[4], wx, wy);
+        *(dst++) = _pix_saucemix(pts[0], pts[1], pts[2], pts[3], wx, wy);
     }
 }
 


### PR DESCRIPTION
The function twin_pixmap_read_xform_8() applies a linear transformation to an 8-bit pixmap. Due to discretization considerations in computer graphics, the output is usually calculated using backward interpolation (i.e.,_pix_saucemix).

This commit identifies two potential bugs in the implementation. The first bug is that the coordinate calculation for pts[3] should be (sx + 1, sy + 1). The second bug is that _pix_saucemix() should take pts[3] instead of pts[4]. Using pts[4] not only violates the definition of `twin_a8_t pts[4];` but also makes no sense since the four calls to _get_pix_8() are intended to obtain the top-left, top-right, bottom-left, and bottom-right pixels.

Additionally, this commit eliminates the only existing warnings in the project.