### PR TITLE
Add preliminary CI scripts

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(c|cxx|cpp|h|hpp)\$")
+
+set -x
+
+for file in ${SOURCES};
+do
+    clang-format-18 ${file} > expected-format
+    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
+done
+exit $(clang-format-18 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")

--- a/.ci/check-newline.sh
+++ b/.ci/check-newline.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+ret=0
+show=0
+# Reference: https://medium.com/@alexey.inkin/how-to-force-newline-at-end-of-files-and-why-you-should-do-it-fdf76d1d090e
+while IFS= read -rd '' f; do
+    if file --mime-encoding "$f" | grep -qv binary; then
+        tail -c1 < "$f" | read -r _ || show=1
+        if [ $show -eq 1 ]; then
+            echo "Warning: No newline at end of file $f"
+            ret=1
+            show=0
+        fi
+    fi
+done < <(git ls-files -z src tests/arch-test-target)
+
+exit $ret

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  detect-code-related-file-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+      - name: Test changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+              .ci/**
+              mk/**
+              include/**
+              src/**
+              backend/**
+              apps/**
+              tools/**
+              .clang-format
+              Makefile
+      - name: Set has_code_related_changes
+        id: set_has_code_related_changes
+        run: |
+          if [[ ${{ steps.changed-files.outputs.any_changed }} == true ]]; then
+            echo "has_code_related_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_code_related_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+  host-x64:
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: install-dependencies
+      run: |
+            sudo apt-get update -q -y
+            sudo apt install libsdl2-dev libjpeg-dev libpng-dev
+      shell: bash
+    - name: default build
+      run: make
+
+  coding-style:
+    needs: [detect-code-related-file-changes]
+    if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: coding convention
+      run: |
+            sudo apt-get install -q -y clang-format-18
+            .ci/check-newline.sh
+            .ci/check-format.sh
+      shell: bash


### PR DESCRIPTION
Indent all C source files with clang-format-12 and force newline at the end of files.
At present, "make" is the only way to validate the build. Later, we may perform headless validation for a file loopback device-based backend, allowing checks of the window system internals.