### PR TITLE
Replace sprintf with snprintf

### DIFF
--- a/tools/font-edit/twin-fedit.c
+++ b/tools/font-edit/twin-fedit.c
@@ -338,7 +338,7 @@ static void draw_char(char_t *c)
                 cairo_set_source_rgb(cr, 0, .5, .5);
 
             cairo_move_to(cr, tx - 2, ty + 3);
-            sprintf(buf, "%d", i);
+            snprintf(buf, sizeof(buf) + 1, "%d", i);
             cairo_show_text(cr, buf);
             cairo_restore(cr);
         }


### PR DESCRIPTION
In C99 7.19.6.5 sprintf, "If copying takes place between objects that overlap, the behavior is undefined".

Replace sprintf with snprintf and provide a clear buffer size to ensure undefined behavior does not occur.

And the sizeof(buff) + 1 includes the null terminator.