### PR TITLE
Fix segmentation fault after destorying window

### DIFF
--- a/backend/sdl.c
+++ b/backend/sdl.c
@@ -58,12 +58,12 @@ static void _twin_sdl_put_span(twin_coord_t left,
 
 static void _twin_sdl_destroy(twin_screen_t *screen, twin_sdl_t *tx)
 {
-    twin_screen_destroy(screen);
-
     SDL_DestroyTexture(tx->texture);
     SDL_DestroyRenderer(tx->render);
     SDL_DestroyWindow(tx->win);
     SDL_Quit();
+
+    twin_screen_destroy(screen);
 }
 
 static void twin_sdl_damage(twin_screen_t *screen, twin_sdl_t *tx)


### PR DESCRIPTION
Function _twin_sdl_destroy destroys the screen before the backend destroyed. This causes a segmentation fault or an endless loop. This commit changes the sequence of destruction in the function.