### PR TITLE
Exclude more generated files from the Git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ libapps.a
 config.h
 __pycache__
 *.pyc
+*.sw*
 
 # Tools
 tools/ttf/twin-ttf


### PR DESCRIPTION
This untrack files naming with `*.sw*` for Vim.