### PR TITLE
Change sprintf to snprintf

### DIFF
--- a/apps/calc.c
+++ b/apps/calc.c
@@ -92,7 +92,7 @@ static int _apps_calc_button_to_id(apps_calc_t *calc, twin_button_t *button)
 static void _apps_calc_update_value(apps_calc_t *calc)
 {
     char v[20];
-    
+
     snprintf(v, sizeof(v) + 1, "%d", calc->stack[0]);
     twin_label_set(calc->display, v, APPS_CALC_VALUE_FG, APPS_CALC_VALUE_SIZE,
                    APPS_CALC_VALUE_STYLE);

--- a/apps/calc.c
+++ b/apps/calc.c
@@ -92,8 +92,8 @@ static int _apps_calc_button_to_id(apps_calc_t *calc, twin_button_t *button)
 static void _apps_calc_update_value(apps_calc_t *calc)
 {
     char v[20];
-
-    sprintf(v, "%d", calc->stack[0]);
+    
+    snprintf(v, sizeof(v) + 1, "%d", calc->stack[0]);
     twin_label_set(calc->display, v, APPS_CALC_VALUE_FG, APPS_CALC_VALUE_SIZE,
                    APPS_CALC_VALUE_STYLE);
 }


### PR DESCRIPTION
`sprintf` does not perform any bounds checking, which could potentially lead to occurence of buffer overflow and cause undefined behavior.

`snprintf` require to specify the size of buffer so that it is able to prevent undefined behavior. Adding `sizeof(v) + 1` to include null terminator.


Reference:
https://www.gnu.org/software/libc/manual/html_node/Formatted-Output-Functions.html