### PR TITLE
font-edit: Improve the type descriptions

### DIFF
--- a/tools/font-edit/twin-fedit.h
+++ b/tools/font-edit/twin-fedit.h
@@ -42,7 +42,7 @@
  * @x: x-component
  * @y: y-component
  */
-typedef struct {
+typedef struct _pt {
     double x, y;
 } pt_t;
 
@@ -52,7 +52,7 @@ typedef struct {
  * @s: size of the storage
  * @pt: pointer of pt_ts
  */
-typedef struct _pts_t {
+typedef struct _pts {
     int n;
     int s;
     pt_t *pt;
@@ -71,7 +71,7 @@ typedef struct _spline {
 
 /* Command line tpyes */
 
-typedef enum _op { OpMove, OpLine, OpCurve, OpNoop } op_t;
+typedef enum { op_move, op_line, op_curve, op_noop } op_t;
 
 typedef struct _cmd {
     struct _cmd *next;

--- a/tools/font-edit/twin-fedit.h
+++ b/tools/font-edit/twin-fedit.h
@@ -35,11 +35,43 @@
 #include <string.h>
 #include <unistd.h>
 
-typedef enum _op { OpMove, OpLine, OpCurve, OpNoop } op_t;
+/* Geometric types */
 
+/*
+ * pt_t - Point in a 2-D coordinate system
+ * @x: x-component
+ * @y: y-component
+ */
 typedef struct {
     double x, y;
 } pt_t;
+
+/*
+ * pts_t - Points in a 2-D coordinate system
+ * @n: numeber of the stored points
+ * @s: size of the storage
+ * @pt: pointer of pt_ts
+ */
+typedef struct _pts_t {
+    int n;
+    int s;
+    pt_t *pt;
+} pts_t;
+
+/*
+ * spline_t - Cubic spline type
+ * @a: starting point.
+ * @b: first control point.
+ * @c: last control point.
+ * @d: ending point.
+ */
+typedef struct _spline {
+    pt_t a, b, c, d;
+} spline_t;
+
+/* Command line tpyes */
+
+typedef enum _op { OpMove, OpLine, OpCurve, OpNoop } op_t;
 
 typedef struct _cmd {
     struct _cmd *next;
@@ -59,30 +91,74 @@ typedef struct _char {
     cmd_t *last;
 } char_t;
 
-typedef struct _pts_t {
-    int n;
-    int s;
-    pt_t *pt;
-} pts_t;
+/* Geometric functions */
 
-typedef struct _spline {
-    pt_t a, b, c, d;
-} spline_t;
-
-spline_t fit(pt_t *p, int n);
-
+/*
+ * new_pts() - Allocate and initialize a new point
+ *
+ * Return: pts_t type, allocated point.
+ */
 pts_t *new_pts(void);
 
+/*
+ * dispose_pts() - Free all storage used by pts_t
+ * @pts: the points to be free
+ */
 void dispose_pts(pts_t *pts);
 
+/*
+ * add_pt() - Add a point to pts_t
+ * @pts: the object that receives the added points
+ * @pt: the point to be added
+ */
 void add_pt(pts_t *pts, pt_t *pt);
 
+/*
+ * distance_to_point() - Calculate distance between two points
+ * @a: point in 2-D coordinate
+ * @b: point in 2-D coordinate
+ *
+ * Return: double type, the distance between point a and point b.
+ */
 double distance_to_point(pt_t *a, pt_t *b);
 
+/*
+ * distance_to_line() - Calculate distance from a point to a line
+ * @p: point outside the line
+ * @p1: one of the points used to calculate the line
+ * @p2: one of the points used to calculate the line
+ *
+ * Return: double type, the distance from point p to the line.
+ */
 double distance_to_line(pt_t *p, pt_t *p1, pt_t *p2);
 
+/*
+ * distance_to_segment() - Calculate shortest distance from a point
+ *                         to a line segment
+ * @p: point outside the line segment
+ * @p1: one of the points used to calculate the line segment
+ * @p2: one of the points used to calculate the line segment
+ *
+ * Return: double type, the distance from point p to the line segment.
+ */
 double distance_to_segment(pt_t *p, pt_t *p1, pt_t *p2);
 
+/*
+ * lerp() - Interpolate linearly a point between two points
+ * @a: one of the point to be interpolated
+ * @b: one of the point to be interpolated
+ *
+ * Return: pt_t type, a interpolation point by two points.
+ */
 pt_t lerp(pt_t *a, pt_t *b);
+
+/*
+ * fit() - Fit a spline within a specified tolerance
+ * @a: points
+ * @n: number of points
+ *
+ * Return: spline_t type, a cubic spline of points.
+ */
+spline_t fit(pt_t *p, int n);
 
 #endif /* _TWIN_FEDIT_H_ */


### PR DESCRIPTION
Currently, the font-edit tool relies on Xlib. According to #7, font-edit should be restructured using SDL2 to enhance portability.

Before proceeding with this work, it is necessary to understand the significance and operational principles of TWIN’s existing functionality. Therefore, we first need to add clear comments to the typedefs and functions in twin-fedit.h to provide a basis for future modifications and porting to SDL2.

To avoid disrupting other developers who might be using the tool during this process, a new branch named font-edit is created.