### PR TITLE
Exclude more generated files from the Git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,32 @@
 # Generated
+*.d
 *.o
-*.o.d
-demo-sdl
-.demo-sdl
-libtwin.a
-.libtwin.a
-libbackend.a
-.libbackend.a
-libapps.a
-.libapps.a
+*.a
+demo-*
+.demo-*
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Vim session
+Session.vim
+Sessionx.vim
+
+# Tag files
+tags
+
+# Python
+__pycache__/
+*.pyc
+
+# Configuration
 .config
 .config.old
 config.h
-__pycache__
-*.pyc
 
 # Tools
 tools/ttf/twin-ttf


### PR DESCRIPTION
Add exclusions for swap files, Vim session records, and tag files using the .gitignore generator

Re-open for #23:

> Use tools such as [.gitignore generator](https://mrkandreev.name/snippets/gitignore-generator/) to improve .gitignore. In particular, C and Python are major programming languages used by this project.
