### PR TITLE
calc: Set maximum digit length to 9

### DIFF
--- a/apps/calc.c
+++ b/apps/calc.c
@@ -119,6 +119,12 @@ static void _apps_calc_digit(apps_calc_t *calc, int digit)
         calc->stack[0] = 0;
         calc->pending_delete = false;
     }
+
+    /* When the length reaches 9 digits, pressing the digit button will not
+     * increase the number of digits. */
+    if (calc->stack[0] > 99999999)
+        return;
+
     calc->stack[0] = calc->stack[0] * 10 + digit;
     _apps_calc_update_value(calc);
 }


### PR DESCRIPTION
According to #25, we find that the input number is random if the digits of the number is larger than 9 digits.
The type of calc->stack[0] is int, and the maximum value for an int is 2,147,483,647. Conservatively, we ensure that when the length reaches 9 digits, pressing the digit button will not increase the number of digits.


![Screen Recording 2024-08-22 151523](https://github.com/user-attachments/assets/6ff7f7d8-3ba3-46c6-8052-d7e6d2cde199)
