### PR TITLE
Fix heap-buffer-overflow in _twin_edge_fill function

### DIFF
--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -28,7 +28,7 @@ twin_pixmap_t *twin_pixmap_create(twin_format_t format,
     pixmap->height = height;
     twin_matrix_identity(&pixmap->transform);
     pixmap->clip.left = pixmap->clip.top = 0;
-    pixmap->clip.right = pixmap->width;
+    pixmap->clip.right = pixmap->width - 1;
     pixmap->clip.bottom = pixmap->height;
     pixmap->origin_x = pixmap->origin_y = 0;
     pixmap->stride = stride;
@@ -58,7 +58,7 @@ twin_pixmap_t *twin_pixmap_create_const(twin_format_t format,
     pixmap->height = height;
     twin_matrix_identity(&pixmap->transform);
     pixmap->clip.left = pixmap->clip.top = 0;
-    pixmap->clip.right = pixmap->width;
+    pixmap->clip.right = pixmap->width - 1;
     pixmap->clip.bottom = pixmap->height;
     pixmap->origin_x = pixmap->origin_y = 0;
     pixmap->stride = stride;
@@ -222,8 +222,8 @@ void twin_pixmap_clip(twin_pixmap_t *pixmap,
         pixmap->clip.left = 0;
     if (pixmap->clip.top < 0)
         pixmap->clip.top = 0;
-    if (pixmap->clip.right > pixmap->width)
-        pixmap->clip.right = pixmap->width;
+    if (pixmap->clip.right > pixmap->width - 1)
+        pixmap->clip.right = pixmap->width - 1;
     if (pixmap->clip.bottom > pixmap->height)
         pixmap->clip.bottom = pixmap->height;
 }
@@ -260,7 +260,7 @@ void twin_pixmap_reset_clip(twin_pixmap_t *pixmap)
 {
     pixmap->clip.left = 0;
     pixmap->clip.top = 0;
-    pixmap->clip.right = pixmap->width;
+    pixmap->clip.right = pixmap->width - 1;
     pixmap->clip.bottom = pixmap->height;
 }
 


### PR DESCRIPTION
Resolved a heap-buffer-overflow in _twin_edge_fill by adding proper bounds checking to prevent _span_fill from accessing out-of-bounds memory. The MIN macro was introduced to ensure x coordinates do not exceed the width of the pixmap.

We fix the part of the memory issues detected by AddressSanitizer:

See: #49

The current Sanitizer result is:
```
=================================================================
==11185==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 49152 byte(s) in 1 object(s) allocated from:
    #0 0x7ff3cd4ebb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x55bc52a396a6 in _twin_gif_to_pixmap (/home/ben/side_project/mado/demo-sdl+0x396a6)

Direct leak of 2064 byte(s) in 2 object(s) allocated from:
    #0 0x7ff3cd4ebf30 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef30)
    #1 0x7ff3ca4acc5c  (/lib/x86_64-linux-gnu/libdbus-1.so.3+0x32c5c)
    #2 0x7ffffffff  (<unknown module>)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ff3cd4ebb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x55bc52a1b4aa in twin_path_create (/home/ben/side_project/mado/demo-sdl+0x1b4aa)

Direct leak of 16 byte(s) in 1 object(s) allocated from:
    #0 0x7ff3cd4ebf30 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef30)
    #1 0x7ff3cbe429d9  (/usr/lib/x86_64-linux-gnu/libX11.so.6+0x569d9)

Indirect leak of 2048 byte(s) in 1 object(s) allocated from:
    #0 0x7ff3cd4ebf30 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef30)
    #1 0x55bc52a19747 in _twin_path_sdraw (/home/ben/side_project/mado/demo-sdl+0x19747)

Indirect leak of 160 byte(s) in 2 object(s) allocated from:
    #0 0x7ff3cd4ebd28 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded28)
    #1 0x7ff3cbe429ae  (/usr/lib/x86_64-linux-gnu/libX11.so.6+0x569ae)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7ff3cd4ebf30 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef30)
    #1 0x55bc52a193e3 in _twin_path_sfinish (/home/ben/side_project/mado/demo-sdl+0x193e3)

Indirect leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7ff3cd4ebb40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7ff3cbe43332  (/usr/lib/x86_64-linux-gnu/libX11.so.6+0x57332)

SUMMARY: AddressSanitizer: 53592 byte(s) leaked in 11 allocation(s)
```