### PR TITLE
Port font editor to SDL2

### DIFF
--- a/tools/font-edit/Makefile
+++ b/tools/font-edit/Makefile
@@ -1,7 +1,7 @@
 TARGET = twin-fedit
 
-CFLAGS = $(shell pkg-config --cflags cairo x11) -g -Wall
-LIBS = $(shell pkg-config --libs cairo x11)
+CFLAGS = $(shell pkg-config --cflags cairo) $(shell sdl2-config --cflags) -g -Wall 
+LIBS = $(shell pkg-config --libs cairo) $(shell sdl2-config --libs)
 
 OBJS = \
 	twin-fedit.o \

--- a/tools/font-edit/README.md
+++ b/tools/font-edit/README.md
@@ -5,7 +5,7 @@ screens.
 
 ## Build Dependency
 ```shell
-sudo apt-get install libx11-dev libcairo2-dev
+sudo apt-get install libsdl2-dev libcairo2-dev
 ```
 
 ## Usage

--- a/tools/font-edit/twin-fedit.h
+++ b/tools/font-edit/twin-fedit.h
@@ -23,11 +23,8 @@
 #ifndef _TWIN_FEDIT_H_
 #define _TWIN_FEDIT_H_
 
-#include <X11/Xatom.h>
-#include <X11/Xlib.h>
-#include <X11/Xutil.h>
-#include <X11/keysym.h>
-#include <cairo-xlib.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_keycode.h>
 #include <cairo.h>
 #include <math.h>
 #include <stdio.h>


### PR DESCRIPTION
Replace X11 with SDL2 to improve the portability and cross-platform support

Migrated window creation from X11's `XCreateWindow` to `SDL_CreateWindow`.

Replaced X11 event handling with SDL2’s event loop (`SDL_PollEvent`) to capture input events such as keyboard and mouse interactions.

Updated rendering to use `SDL_Renderer` and `SDL_Surface`, replacing X11's rendering functions.

* Modified some key event logic:
1. SDLK_ESCAPE: ESC now exits the program.
2. SDL_QUIT: Clicking the "X" on the window exits the program.

* Unchanged key event logic:
1. SDLK_q: Switches to the next font.

* Features not fully implemented yet:
1. SDLK_s, SDLK_u, SDLK_f, SDLK_d, SDLK_DOWN: Handling logic for stripe drawing operations.
2. SDL_WINDOWEVENT, SDL_MOUSEBUTTONDOWN.

Related issue #7 