### PR TITLE
Fix timeout processing order

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -28,9 +28,9 @@ static twin_order_t _twin_timeout_order(twin_queue_t *a, twin_queue_t *b)
     const twin_timeout_t *bt = (twin_timeout_t *) b;
 
     if (twin_time_compare(at->time, <, bt->time))
-        return TWIN_BEFORE;
-    if (twin_time_compare(at->time, >, bt->time))
         return TWIN_AFTER;
+    if (twin_time_compare(at->time, >, bt->time))
+        return TWIN_BEFORE;
     return TWIN_AT;
 }
 


### PR DESCRIPTION
I noticed the GIF frame rate is slower than expected when combined with the clock app. Upon checking the `_twin_run_timeout` function, I discovered that the processing queue handles events from larger to smaller time ticks. I fixed this by changing the order to process from smaller to larger time ticks, ensuring timeout events are handled sequentially.
Before:
![before](https://github.com/user-attachments/assets/61b2de8c-dcbd-42d0-bdc9-1ac2349f3750)
After:
![after](https://github.com/user-attachments/assets/1d785c39-a208-405c-857e-14e051a241a2)