### PR TITLE
Fix the heap-use-after-free and memory leak

### DIFF
--- a/apps/multi.c
+++ b/apps/multi.c
@@ -216,6 +216,7 @@ static void apps_jelly_start(twin_screen_t *screen, int x, int y, int w, int h)
             twin_path_destroy(stroke);
         }
     }
+    twin_path_destroy(path);
     twin_window_show(window);
 }
 

--- a/backend/sdl.c
+++ b/backend/sdl.c
@@ -62,8 +62,6 @@ static void _twin_sdl_destroy(twin_screen_t *screen, twin_sdl_t *tx)
     SDL_DestroyRenderer(tx->render);
     SDL_DestroyWindow(tx->win);
     SDL_Quit();
-
-    twin_screen_destroy(screen);
 }
 
 static void twin_sdl_damage(twin_screen_t *screen, twin_sdl_t *tx)

--- a/src/image-gif.c
+++ b/src/image-gif.c
@@ -600,10 +600,12 @@ static twin_animation_t *_twin_animation_from_gif_file(const char *path)
     }
     anim->iter = twin_animation_iter_init(anim);
     if (!anim->iter) {
+        free(frame);
         free(anim);
         gif_close(gif);
         return NULL;
     }
+    free(frame);
     gif_close(gif);
     return anim;
 }


### PR DESCRIPTION
To fix the heap-use-after-free issue when `screen` is accessed by the `twin_sdl_work()` function, remove the `_twin_sdl_destroy(screen, tx)` operation. Additionally, to address the memory leak, add the `twin_path_destroy(path)` function to ensure the unused path is properly destroyed.

Close sysprog21#49