### PR TITLE
Decouple toolchain configurations

### DIFF
--- a/mk/common.mk
+++ b/mk/common.mk
@@ -90,23 +90,7 @@
 
 TOPDIR ?= $(CURDIR)
 
-CC         := $(CROSS_COMPILE)gcc $(SYSROOT)
-CXX        := $(CROSS_COMPILE)g++ $(SYSROOT)
-CPP        := $(CROSS_COMPILE)cpp $(SYSROOT)
-LD         := $(CROSS_COMPILE)ld
-AR         := $(CROSS_COMPILE)ar
-RANLIB     := $(CROSS_COMPILE)ranlib
-STRIP      := $(CROSS_COMPILE)strip -sx
-OBJCOPY    := $(CROSS_COMPILE)objcopy
-
-HOSTCC     := $(HOST_COMPILE)gcc
-HOSTCXX    := $(HOST_COMPILE)g++
-HOSTCPP    := $(HOST_COMPILE)cpp
-HOSTLD     := $(HOST_COMPILE)ld
-HOSTAR     := $(HOST_COMPILE)ar
-HOSTRANLIB := $(HOST_COMPILE)ranlib
-HOSTSTRIP  := $(HOST_COMPILE)strip
-HOSTOBJCOPY:= $(HOST_COMPILE)objcpy
+include mk/toolchain.mk
 
 SED        := sed
 
@@ -116,8 +100,8 @@ MV         := mv
 RM         := rm -rf
 MKDIR      := mkdir -p
 
-__CFLAGS := -Wall -Wextra -pipe
-__CFLAGS += -O2 -pipe
+__CFLAGS := -Wall -Wextra
+__CFLAGS += -O2
 __CFLAGS += $(CFLAGS)
 
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -1,0 +1,85 @@
+CC_IS_CLANG :=
+CC_IS_GCC :=
+
+# FIXME: Cross-compilation using Clang is not supported.
+ifdef CROSS_COMPILE
+CC := $(CROSS_COMPILE)gcc
+endif
+
+override CC := $(shell which $(CC))
+ifndef CC
+$(error "Valid C compiler not found.")
+endif
+
+ifneq ($(shell $(CC) --version | head -n 1 | grep clang),)
+CC_IS_CLANG := 1
+else ifneq ($(shell $(CC) --version | grep "Free Software Foundation"),)
+CC_IS_GCC := 1
+endif
+
+ifeq ("$(CC_IS_CLANG)$(CC_IS_GCC)", "")
+$(warning Unsupported C compiler)
+endif
+
+ifndef CXX
+CXX := $(CROSS_COMPILE)g++
+endif
+ifeq ("$(CC_IS_CLANG)", "1")
+override CXX := $(dir $(CC))$(subst clang,clang++,$(notdir $(CC)))
+endif
+
+ifndef CPP
+CPP := $(CC) -E
+endif
+
+ifndef LD
+LD := $(CROSS_COMPILE)ld
+endif
+
+ifndef AR
+AR := $(CROSS_COMPILE)ar
+endif
+
+ifndef RANLIB
+RANLIB := $(CROSS_COMPILE)ranlib
+endif
+
+ifndef STRIP
+STRIP := $(CROSS_COMPILE)strip -sx
+endif
+
+ifndef OBJCOPY
+OBJCOPY := $(CROSS_COMPILE)objcopy
+endif
+
+ifndef HOSTCC
+HOSTCC := $(HOST_COMPILE)gcc
+endif
+
+ifndef HOSTCXX
+HOSTCXX := $(HOST_COMPILE)g++
+endif
+
+ifndef HOSTCPP
+HOSTCPP := $(HOSTCC) -E
+endif
+
+ifndef HOSTLD
+HOSTLD := $(HOST_COMPILE)ld
+endif
+
+ifndef HOSTAR
+HOSTAR := $(HOST_COMPILE)ar
+endif
+
+ifndef HOSTRANLIB
+HOSTRANLIB := $(HOST_COMPILE)ranlib
+endif
+
+ifndef HOSTSTRIP
+HOSTSTRIP := $(HOST_COMPILE)strip
+endif
+
+ifndef HOSTOBJCOPY
+HOSTOBJCOPY:= $(HOST_COMPILE)objcpy
+endif


### PR DESCRIPTION
In preparation for cross-compilation support, the toolchain specific configurations have been decoupled from the build system. Preliminary checks have been added to determine the supported compilers, GCC and Clang. When 'CROSS_COMPILE' is set, the build system will honor it and set CC accordingly. Currently, only the GNU toolchain is supported for cross-compilation.