### PR TITLE
Use enum for font styles instead of macros

### DIFF
--- a/apps/calc.c
+++ b/apps/calc.c
@@ -73,11 +73,11 @@ static const char *apps_calc_labels[] = {
 };
 
 #define APPS_CALC_VALUE_SIZE twin_int_to_fixed(29)
-#define APPS_CALC_VALUE_STYLE TWIN_TEXT_ROMAN
+#define APPS_CALC_VALUE_STYLE TwinStyleRoman
 #define APPS_CALC_VALUE_FG 0xff000000
 #define APPS_CALC_VALUE_BG 0x80808080
 #define APPS_CALC_BUTTON_SIZE twin_int_to_fixed(15)
-#define APPS_CALC_BUTTON_STYLE TWIN_TEXT_BOLD
+#define APPS_CALC_BUTTON_STYLE TwinStyleBold
 #define APPS_CALC_BUTTON_FG 0xff000000
 #define APPS_CALC_BUTTON_BG 0xc0808080
 

--- a/apps/clock.c
+++ b/apps/clock.c
@@ -103,7 +103,7 @@ static void _apps_clock_date(apps_clock_t *clock, struct tm *t)
     twin_path_rotate(path, TWIN_ANGLE_90);
     twin_path_translate(path, D(0.8), 0);
     twin_path_set_font_size(path, D(0.25));
-    twin_path_set_font_style(path, TWIN_TEXT_UNHINTED);
+    twin_path_set_font_style(path, TwinStyleUnhinted);
     twin_text_metrics_utf8(path, text, &metrics);
     height = metrics.ascent + metrics.descent;
     width = metrics.right_side_bearing - metrics.left_side_bearing;
@@ -133,7 +133,7 @@ static void _apps_clock_face(apps_clock_t *clock)
                       APPS_CLOCK_BORDER_WIDTH);
 
     twin_path_set_font_size(path, D(0.2));
-    twin_path_set_font_style(path, TWIN_TEXT_UNHINTED);
+    twin_path_set_font_style(path, TwinStyleUnhinted);
 
     for (m = 1; m <= 60; m++) {
         twin_state_t state = twin_path_save(path);

--- a/apps/hello.c
+++ b/apps/hello.c
@@ -20,7 +20,7 @@ static twin_time_t _apps_hello_timeout(twin_time_t maybe_unused now,
 
     *strchr(t, '\n') = '\0';
     twin_label_set(labelb, t, 0xff008000, twin_int_to_fixed(12),
-                   TWIN_TEXT_OBLIQUE);
+                   TwinStyleOblique);
     return 1000;
 }
 
@@ -34,14 +34,14 @@ void apps_hello_start(twin_screen_t *screen,
     twin_toplevel_t *top = twin_toplevel_create(
         screen, TWIN_ARGB32, TwinWindowApplication, x, y, w, h, name);
     twin_label_t *labela = twin_label_create(
-        &top->box, name, 0xff000080, twin_int_to_fixed(12), TWIN_TEXT_ROMAN);
+        &top->box, name, 0xff000080, twin_int_to_fixed(12), TwinStyleRoman);
     twin_widget_t *widget =
         twin_widget_create(&top->box, 0xff800000, 1, 2, 0, 0);
     twin_label_t *labelb = twin_label_create(
-        &top->box, name, 0xff008000, twin_int_to_fixed(12), TWIN_TEXT_OBLIQUE);
+        &top->box, name, 0xff008000, twin_int_to_fixed(12), TwinStyleOblique);
     twin_button_t *button = twin_button_create(
         &top->box, "Button", 0xff800000, twin_int_to_fixed(18),
-        TWIN_TEXT_BOLD | TWIN_TEXT_OBLIQUE);
+        TwinStyleBold | TwinStyleOblique);
     twin_widget_set(&labela->widget, 0xc0c0c0c0);
     (void) widget;
     twin_widget_set(&labelb->widget, 0xc0c0c0c0);

--- a/apps/multi.c
+++ b/apps/multi.c
@@ -51,7 +51,7 @@ static void apps_circletext_start(twin_screen_t *screen,
     twin_fill(pixmap, 0xffffffff, TWIN_SOURCE, 0, 0, wid, hei);
     twin_window_set_name(window, "circletext");
 
-    twin_path_set_font_style(path, TWIN_TEXT_UNHINTED);
+    twin_path_set_font_style(path, TwinStyleUnhinted);
     twin_path_circle(pen, 0, 0, D(1));
 
     twin_path_translate(path, D(200), D(200));
@@ -193,7 +193,7 @@ static void apps_jelly_start(twin_screen_t *screen, int x, int y, int w, int h)
         fy += D(s + 2);
         twin_path_move(path, fx, fy);
 #define TEXT "jelly text"
-        /*	twin_path_set_font_style (path, TWIN_TEXT_UNHINTED); */
+        /* twin_path_set_font_style (path, TwinStyleUnhinted); */
         twin_path_utf8(path, TEXT);
         twin_paint_path(pixmap, 0xff000000, path);
         twin_path_empty(path);

--- a/include/twin.h
+++ b/include/twin.h
@@ -16,7 +16,6 @@ typedef uint16_t twin_rgb16_t;
 typedef uint32_t twin_argb32_t;
 typedef uint32_t twin_ucs4_t;
 typedef int16_t twin_coord_t;
-typedef int16_t twin_style_t;
 typedef int16_t twin_count_t;
 typedef int16_t twin_keysym_t;
 typedef uint8_t twin_js_number_t;
@@ -320,6 +319,14 @@ typedef struct _twin_point {
 } twin_point_t;
 
 typedef struct _twin_path twin_path_t;
+
+typedef enum _twin_style {
+    TwinStyleRoman = 0,
+    TwinStyleBold = 1,
+    TwinStyleOblique = 2,
+    TwinStyleBoldOblique = 3,
+    TwinStyleUnhinted = 4,
+} twin_style_t;
 
 typedef enum _twin_cap {
     TwinCapRound,
@@ -672,11 +679,6 @@ twin_fixed_t twin_fixed_sqrt(twin_fixed_t a);
  */
 
 bool twin_has_ucs4(twin_font_t *font, twin_ucs4_t ucs4);
-
-#define TWIN_TEXT_ROMAN 0
-#define TWIN_TEXT_BOLD 1
-#define TWIN_TEXT_OBLIQUE 2
-#define TWIN_TEXT_UNHINTED 4
 
 void twin_path_ucs4_stroke(twin_path_t *path, twin_ucs4_t ucs4);
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -692,12 +692,11 @@ static twin_argb32_t _twin_apply_alpha(twin_argb32_t v)
     );
 
     /* clear RGB data if alpha is zero */
-
     if (!alpha)
         return 0;
 
-        /* twin needs ARGB format */
 #if __BYTE_ORDER == __BIG_ENDIAN
+    /* twin needs ARGB format */
     return alpha << 24 | twin_int_mult(twin_get_8(v, 24), alpha, t1) << 16 |
            twin_int_mult(twin_get_8(v, 16), alpha, t2) << 8 |
            twin_int_mult(twin_get_8(v, 8), alpha, t3) << 0;

--- a/src/font.c
+++ b/src/font.c
@@ -34,7 +34,7 @@ static void _twin_text_compute_info(twin_path_t *path,
     /*
      * Only hint axis aligned text
      */
-    if ((path->state.font_style & TWIN_TEXT_UNHINTED) == 0 &&
+    if ((path->state.font_style & TwinStyleUnhinted) == 0 &&
         ((path->state.matrix.m[0][1] == 0 && path->state.matrix.m[1][0] == 0) ||
          (path->state.matrix.m[0][0] == 0 &&
           path->state.matrix.m[1][1] == 0))) {
@@ -94,7 +94,7 @@ static void _twin_text_compute_info(twin_path_t *path,
         info->margin.x = info->pen.x;
         info->margin.y = info->pen.y;
         if (font->type == TWIN_FONT_TYPE_STROKE &&
-            (path->state.font_style & TWIN_TEXT_BOLD)) {
+            (path->state.font_style & TwinStyleBold)) {
             twin_fixed_t pen_x_add;
             twin_fixed_t pen_y_add;
 
@@ -126,7 +126,7 @@ static void _twin_text_compute_info(twin_path_t *path,
             info->pen.x = info->pen.y = 0;
             info->margin.x = info->margin.y = 0;
         } else {
-            if (path->state.font_style & TWIN_TEXT_BOLD)
+            if (path->state.font_style & TwinStyleBold)
                 info->pen.x = path->state.font_size / 16;
             else
                 info->pen.x = path->state.font_size / 24;
@@ -143,7 +143,7 @@ static void _twin_text_compute_info(twin_path_t *path,
     info->pen_matrix.m[2][1] = 0;
     twin_matrix_scale(&info->pen_matrix, info->pen.x, info->pen.y);
 
-    if (path->state.font_style & TWIN_TEXT_OBLIQUE) {
+    if (path->state.font_style & TwinStyleOblique) {
         twin_matrix_t m;
 
         m.m[0][0] = TWIN_FIXED_ONE;

--- a/src/path.c
+++ b/src/path.c
@@ -440,7 +440,7 @@ twin_path_t *twin_path_create(void)
     path->sublen = 0;
     twin_matrix_identity(&path->state.matrix);
     path->state.font_size = TWIN_FIXED_ONE * 15;
-    path->state.font_style = TWIN_TEXT_ROMAN;
+    path->state.font_style = TwinStyleRoman;
     path->state.cap_style = TwinCapRound;
     return path;
 }

--- a/src/window.c
+++ b/src/window.c
@@ -199,7 +199,7 @@ static void twin_window_frame(twin_window_t *window)
     if (!name)
         name = "twin";
     twin_path_set_font_size(path, name_height);
-    twin_path_set_font_style(path, TWIN_TEXT_OBLIQUE | TWIN_TEXT_UNHINTED);
+    twin_path_set_font_style(path, TwinStyleOblique | TwinStyleUnhinted);
     text_width = twin_width_utf8(path, name);
 
     title_right = (text_x + text_width + bw + icon_size + bw + icon_size + bw +


### PR DESCRIPTION
There are four supported font styles, originally defined using macros. Switching to enum for these identifiers improves code clarity, self- documentation, and ensures type safety when working with related constants.