### PR TITLE
Fix memory region in framebuffer

### DIFF
--- a/backend/fbdev.c
+++ b/backend/fbdev.c
@@ -56,9 +56,9 @@ static void _twin_fbdev_put_span(twin_coord_t left,
         return;
 
     twin_coord_t width = right - left;
-    off_t off = top * screen->width + left;
-    uint32_t *dest =
-        (uint32_t *) ((uintptr_t) tx->fb_base + (off * sizeof(*dest)));
+    uint32_t *dest;
+    off_t off = sizeof(*dest) * left + top * tx->fb_fix.line_length;
+    dest = (uint32_t *) ((uintptr_t) tx->fb_base + off);
     memcpy(dest, pixels, width * sizeof(*dest));
 }
 


### PR DESCRIPTION
Issue https://github.com/sysprog21/mado/issues/62 
The width of screen may be different from the virtual resolution.
In `apps/main.c`, the default value of `WIDTH` and `HEIGHT` are 640 and 480, but the visual resolution are set to 1920 and 1080 on my machine.
The different width will draw three screens on the display as the below screenshot.

Before:
![screen](https://github.com/user-attachments/assets/5620d08c-be86-4ffe-9809-eb8cd6fafd7d)

After:
![screen](https://github.com/user-attachments/assets/034eb2e3-7fbf-473b-b315-d57e3ea86b05)

The reason to use ~`xres_virtual`~  `line_length` as the width and not to use `xres` in [`struct fb_var_screeninfo`](https://github.com/torvalds/linux/blob/e42b1a9a2557aa94fee47f078633677198386a52/include/linux/fb.h#L828):
On VirtualBox, the visible resolution of virtual terminal, which switched by `ctrl+alt+f3`, is set to 800x600, but the virtual solution is set to 2048x2048. On my physical machine, Asus latop and Ubuntu system, these are the same values. 

The information from `sudo fbset -i` on my laptop and VirtualBox.
Laptop:
```
mode "1920x1080"
    geometry 1920 1080 1920 1080 32
    ....
endmode
Frame buffer device information:
    ....
    LineLength  : 7680
    Accelerator : No
```

VirtualBox:
```
mode "800x600"
    geometry 800 600 2048 2048 32
endmode

Frame buffer device information:
    ......
    LineLength  : 8192
    Accelerator : No
```