### PR TITLE
Support input device hot-plugging and removal via udev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ endif
 
 ifeq ($(CONFIG_BACKEND_FBDEV), y)
 BACKEND = fbdev
+TARGET_LIBS += -ludev
 libtwin.a_files-y += backend/fbdev.c
 libtwin.a_files-y += backend/linux_input.c
 endif

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ For the VNC backend, please note that it has only been tested on GNU/Linux, and 
 $ tools/build-neatvnc.sh
 ```
 
+For Linux framebuffer backend, install `libudev` and `libuuid`:
+* Ubuntu Linux / Debian: `sudo apt install libudev-dev uuid-dev`
+
 ### Configuration
 
 Configure via [Kconfiglib](https://pypi.org/project/kconfiglib/), you should select either SDL video, the Linux framebuffer, or VNC as the graphics backend.


### PR DESCRIPTION
## Overview

`udev` (`userspace /dev`) is a device manager for the Linux kernel. By monitoring `add` and `remove` events from `udev`, we can dynamically update the event device file descriptors table to enable device hot-plugging and removal.

## Prerequisites

To test the modified code, compile `mado` with the `Linux framebuffer` backend.

## Test procedure

1. Switch to a new virtual terminal (VT) by pressing `Ctrl+Alt+Fn` (e.g., `Ctrl+Alt+F3`) and then execute:

```shell
$ sudo ./demo-fbdev
```

2. Test the new feature by unplugging and reconnecting the mouse.
3. Return to the desktop environment with `Ctrl+Alt+F1`.