### PR TITLE
Support path function to fulfill TinyVG rendering

### DIFF
--- a/apps/multi.c
+++ b/apps/multi.c
@@ -220,6 +220,57 @@ static void apps_jelly_start(twin_screen_t *screen, int x, int y, int w, int h)
     twin_window_show(window);
 }
 
+static void draw_flower(twin_path_t *path,
+                        twin_fixed_t radius,
+                        int number_of_petals)
+{
+    const twin_angle_t angle_shift = TWIN_ANGLE_360 / number_of_petals;
+    const twin_angle_t angle_start = angle_shift / 2;
+    twin_fixed_t s, c;
+    twin_sincos(-angle_start, &s, &c);
+    twin_fixed_t p_x = twin_fixed_mul(radius, c);
+    twin_fixed_t p_y = twin_fixed_mul(radius, s);
+    twin_path_move(path, p_x, p_y);
+
+    for (twin_angle_t a = angle_start; a <= TWIN_ANGLE_360; a += angle_shift) {
+        twin_sincos(a, &s, &c);
+        twin_fixed_t c_x = twin_fixed_mul(radius, c);
+        twin_fixed_t c_y = twin_fixed_mul(radius, s);
+        twin_fixed_t rx = radius;
+        twin_fixed_t ry = radius * 3;
+        twin_path_arc_ellipse(path, 1, 1, rx, ry, p_x, p_y, c_x, c_y,
+                              a - angle_start);
+        p_x = c_x;
+        p_y = c_y;
+    }
+
+    twin_path_close(path);
+}
+
+static void apps_flower_start(twin_screen_t *screen, int x, int y, int w, int h)
+{
+    twin_window_t *window = twin_window_create(
+        screen, TWIN_ARGB32, TwinWindowApplication, x, y, w, h);
+    twin_pixmap_t *pixmap = window->pixmap;
+    twin_path_t *stroke = twin_path_create();
+    twin_path_t *path = twin_path_create();
+    twin_path_translate(path, D(200), D(200));
+    twin_path_scale(path, D(10), D(10));
+    twin_path_translate(stroke, D(200), D(200));
+    twin_fill(pixmap, 0xffffffff, TWIN_SOURCE, 0, 0, w, h);
+    twin_window_set_name(window, "Flower");
+    twin_path_move(stroke, D(-200), D(0));
+    twin_path_draw(stroke, D(200), D(0));
+    twin_path_move(stroke, D(0), D(200));
+    twin_path_draw(stroke, D(0), D(-200));
+    twin_path_set_cap_style(stroke, TwinCapProjecting);
+    twin_paint_stroke(pixmap, 0xffcc9999, stroke, D(10));
+    draw_flower(path, D(3), 5);
+    twin_paint_path(pixmap, 0xffe2d2d2, path);
+    twin_path_destroy(stroke);
+    twin_window_show(window);
+}
+
 void apps_multi_start(twin_screen_t *screen,
                       const char *name,
                       int x,
@@ -233,4 +284,5 @@ void apps_multi_start(twin_screen_t *screen,
     apps_quickbrown_start(screen, x += 20, y += 20, w, h);
     apps_ascii_start(screen, x += 20, y += 20, w, h);
     apps_jelly_start(screen, x += 20, y += 20, w / 2, h);
+    apps_flower_start(screen, x += 20, y += 20, w, h);
 }

--- a/apps/spline.c
+++ b/apps/spline.c
@@ -15,45 +15,86 @@
 
 #define _apps_spline_pixmap(spline) ((spline)->widget.window->pixmap)
 
-#define NPT 4
-
 typedef struct _apps_spline {
     twin_widget_t widget;
-    twin_point_t points[NPT];
+    int n_points;
+    twin_point_t *points;
     int which;
     twin_fixed_t line_width;
     twin_cap_t cap_style;
+    twin_matrix_t transition;
+    twin_matrix_t inverse_transition;
 } apps_spline_t;
+
+static void _init_control_point(apps_spline_t *spline)
+{
+    const int init_point_quad[3][2] = {
+        {100, 100},
+        {200, 100},
+        {300, 100},
+    };
+    const int init_point_cubic[4][2] = {
+        {100, 100},
+        {300, 300},
+        {100, 300},
+        {300, 100},
+    };
+    const int(*init_point)[2];
+    if (spline->n_points == 4) {
+        init_point = init_point_cubic;
+    } else if (spline->n_points == 3) {
+        init_point = init_point_quad;
+    }
+    for (int i = 0; i < spline->n_points; i++) {
+        spline->points[i].x = twin_int_to_fixed(init_point[i][0]);
+        spline->points[i].y = twin_int_to_fixed(init_point[i][1]);
+    }
+}
+
+static void _draw_aux_line(twin_path_t *path,
+                           apps_spline_t *spline,
+                           int idx1,
+                           int idx2)
+{
+    twin_path_move(path, spline->points[idx1].x, spline->points[idx1].y);
+    twin_path_draw(path, spline->points[idx2].x, spline->points[idx2].y);
+    twin_paint_stroke(_apps_spline_pixmap(spline), 0xc08000c0, path,
+                      twin_int_to_fixed(2));
+    twin_path_empty(path);
+}
 
 static void _apps_spline_paint(apps_spline_t *spline)
 {
     twin_path_t *path;
-    int i;
-
     path = twin_path_create();
     twin_path_set_cap_style(path, spline->cap_style);
+    twin_path_set_matrix(path, spline->transition);
+
     twin_path_move(path, spline->points[0].x, spline->points[0].y);
-    twin_path_curve(path, spline->points[1].x, spline->points[1].y,
-                    spline->points[2].x, spline->points[2].y,
-                    spline->points[3].x, spline->points[3].y);
+    if (spline->n_points == 4) {
+        twin_path_curve(path, spline->points[1].x, spline->points[1].y,
+                        spline->points[2].x, spline->points[2].y,
+                        spline->points[3].x, spline->points[3].y);
+    } else if (spline->n_points == 3) {
+        twin_path_quadratic_curve(path, spline->points[1].x,
+                                  spline->points[1].y, spline->points[2].x,
+                                  spline->points[2].y);
+    }
     twin_paint_stroke(_apps_spline_pixmap(spline), 0xff404040, path,
                       spline->line_width);
     twin_path_set_cap_style(path, TwinCapButt);
     twin_paint_stroke(_apps_spline_pixmap(spline), 0xffffff00, path,
                       twin_int_to_fixed(2));
+    twin_path_empty(path);
+    if (spline->n_points == 4) {
+        _draw_aux_line(path, spline, 0, 1);
+        _draw_aux_line(path, spline, 3, 2);
+    } else if (spline->n_points == 3) {
+        _draw_aux_line(path, spline, 0, 1);
+        _draw_aux_line(path, spline, 1, 2);
+    }
 
-    twin_path_empty(path);
-    twin_path_move(path, spline->points[0].x, spline->points[0].y);
-    twin_path_draw(path, spline->points[1].x, spline->points[1].y);
-    twin_paint_stroke(_apps_spline_pixmap(spline), 0xc08000c0, path,
-                      twin_int_to_fixed(2));
-    twin_path_empty(path);
-    twin_path_move(path, spline->points[3].x, spline->points[3].y);
-    twin_path_draw(path, spline->points[2].x, spline->points[2].y);
-    twin_paint_stroke(_apps_spline_pixmap(spline), 0xc08000c0, path,
-                      twin_int_to_fixed(2));
-    twin_path_empty(path);
-    for (i = 0; i < NPT; i++) {
+    for (int i = 0; i < spline->n_points; i++) {
         twin_path_empty(path);
         twin_path_circle(path, spline->points[i].x, spline->points[i].y,
                          twin_int_to_fixed(10));
@@ -62,13 +103,32 @@ static void _apps_spline_paint(apps_spline_t *spline)
     twin_path_destroy(path);
 }
 
+static void _apps_spline_button_signal(maybe_unused twin_button_t *button,
+                                       twin_button_signal_t signal,
+                                       void *closure)
+{
+    if (signal != TwinButtonSignalDown)
+        return;
+
+    apps_spline_t *spline = closure;
+    spline->n_points = (spline->n_points == 3) ? 4 : 3;
+    _init_control_point(spline);
+    _twin_widget_queue_paint(&spline->widget);
+}
+
+#define D(x) twin_double_to_fixed(x)
 static twin_dispatch_result_t _apps_spline_update_pos(apps_spline_t *spline,
                                                       twin_event_t *event)
 {
     if (spline->which < 0)
         return TwinDispatchContinue;
-    spline->points[spline->which].x = twin_int_to_fixed(event->u.pointer.x);
-    spline->points[spline->which].y = twin_int_to_fixed(event->u.pointer.y);
+    twin_fixed_t x = twin_int_to_fixed(event->u.pointer.x);
+    twin_fixed_t y = twin_int_to_fixed(event->u.pointer.y);
+
+    spline->points[spline->which].x = twin_sfixed_to_fixed(
+        _twin_matrix_x(&(spline->inverse_transition), x, y));
+    spline->points[spline->which].y = twin_sfixed_to_fixed(
+        _twin_matrix_y(&(spline->inverse_transition), x, y));
     _twin_widget_queue_paint(&spline->widget);
     return TwinDispatchDone;
 }
@@ -80,11 +140,15 @@ static int _apps_spline_hit(apps_spline_t *spline,
                             twin_fixed_t y)
 {
     int i;
-
-    for (i = 0; i < NPT; i++)
-        if (twin_fixed_abs(x - spline->points[i].x) < spline->line_width / 2 &&
-            twin_fixed_abs(y - spline->points[i].y) < spline->line_width / 2)
+    for (i = 0; i < spline->n_points; i++) {
+        twin_fixed_t px = twin_sfixed_to_fixed(_twin_matrix_x(
+            &(spline->transition), spline->points[i].x, spline->points[i].y));
+        twin_fixed_t py = twin_sfixed_to_fixed(_twin_matrix_y(
+            &(spline->transition), spline->points[i].x, spline->points[i].y));
+        if (twin_fixed_abs(x - px) < spline->line_width / 2 &&
+            twin_fixed_abs(y - py) < spline->line_width / 2)
             return i;
+    }
     return -1;
 }
 
@@ -123,28 +187,36 @@ static twin_dispatch_result_t _apps_spline_dispatch(twin_widget_t *widget,
 
 static void _apps_spline_init(apps_spline_t *spline,
                               twin_box_t *parent,
-                              twin_dispatch_proc_t dispatch)
+                              twin_dispatch_proc_t dispatch,
+                              int n_points)
 {
-    static const twin_widget_layout_t preferred = {0, 0, 1, 1};
+    static twin_widget_layout_t preferred = {0, 0, 1, 1};
+    preferred.height = parent->widget.window->screen->height * 2 / 3;
     _twin_widget_init(&spline->widget, parent, 0, preferred, dispatch);
     twin_widget_set(&spline->widget, 0xffffffff);
     spline->line_width = twin_int_to_fixed(100);
     spline->cap_style = TwinCapRound;
-    spline->points[0].x = twin_int_to_fixed(100);
-    spline->points[0].y = twin_int_to_fixed(100);
-    spline->points[1].x = twin_int_to_fixed(300);
-    spline->points[1].y = twin_int_to_fixed(300);
-    spline->points[2].x = twin_int_to_fixed(100);
-    spline->points[2].y = twin_int_to_fixed(300);
-    spline->points[3].x = twin_int_to_fixed(300);
-    spline->points[3].y = twin_int_to_fixed(100);
+    twin_matrix_identity(&spline->transition);
+    twin_matrix_rotate(&spline->transition, TWIN_ANGLE_11_25);
+    twin_matrix_identity(&spline->inverse_transition);
+    twin_matrix_rotate(&spline->inverse_transition, -TWIN_ANGLE_11_25);
+    spline->points = calloc(n_points, sizeof(twin_point_t));
+    spline->n_points = n_points;
+    _init_control_point(spline);
+    twin_button_t *button =
+        twin_button_create(parent, "SwitchCurve", 0xffae0000, D(10),
+                           TwinStyleBold | TwinStyleOblique);
+    twin_widget_set(&button->label.widget, 0xc0808080);
+    button->signal = _apps_spline_button_signal;
+    button->closure = spline;
+    button->label.widget.shape = TwinShapeRectangle;
 }
 
-static apps_spline_t *apps_spline_create(twin_box_t *parent)
+static apps_spline_t *apps_spline_create(twin_box_t *parent, int n_points)
 {
     apps_spline_t *spline = malloc(sizeof(apps_spline_t));
 
-    _apps_spline_init(spline, parent, _apps_spline_dispatch);
+    _apps_spline_init(spline, parent, _apps_spline_dispatch, n_points);
     return spline;
 }
 
@@ -157,7 +229,7 @@ void apps_spline_start(twin_screen_t *screen,
 {
     twin_toplevel_t *toplevel = twin_toplevel_create(
         screen, TWIN_ARGB32, TwinWindowApplication, x, y, w, h, name);
-    apps_spline_t *spline = apps_spline_create(&toplevel->box);
+    apps_spline_t *spline = apps_spline_create(&toplevel->box, 4);
     (void) spline;
     twin_toplevel_show(toplevel);
 }

--- a/apps/spline.c
+++ b/apps/spline.c
@@ -116,7 +116,6 @@ static void _apps_spline_button_signal(maybe_unused twin_button_t *button,
     _twin_widget_queue_paint(&spline->widget);
 }
 
-#define D(x) twin_double_to_fixed(x)
 static twin_dispatch_result_t _apps_spline_update_pos(apps_spline_t *spline,
                                                       twin_event_t *event)
 {

--- a/include/twin.h
+++ b/include/twin.h
@@ -670,7 +670,7 @@ void twin_clear_file(twin_file_t *file);
  */
 
 #define twin_fixed_mul(a, b) ((twin_fixed_t) (((int64_t) (a) * (b)) >> 16))
-#define twin_fixed_div(a, b) ((twin_fixed_t) ((((int64_t) (a)) << 16) / b))
+#define twin_fixed_div(a, b) ((twin_fixed_t) ((((int64_t) (a)) << 16) / (b)))
 
 twin_fixed_t twin_fixed_sqrt(twin_fixed_t a);
 
@@ -800,6 +800,7 @@ void twin_path_ellipse(twin_path_t *path,
                        twin_fixed_t y,
                        twin_fixed_t x_radius,
                        twin_fixed_t y_radius);
+
 void twin_path_arc(twin_path_t *path,
                    twin_fixed_t x,
                    twin_fixed_t y,
@@ -807,6 +808,26 @@ void twin_path_arc(twin_path_t *path,
                    twin_fixed_t y_radius,
                    twin_angle_t start,
                    twin_angle_t extent);
+
+void twin_path_arc_ellipse(twin_path_t *path,
+                           bool large_arc,
+                           bool sweep,
+                           twin_fixed_t radius_x,
+                           twin_fixed_t radius_y,
+                           twin_fixed_t cur_x,
+                           twin_fixed_t cur_y,
+                           twin_fixed_t target_x,
+                           twin_fixed_t target_y,
+                           twin_angle_t rotation);
+
+void twin_path_arc_circle(twin_path_t *path,
+                          bool large_arc,
+                          bool sweep,
+                          twin_fixed_t radius,
+                          twin_fixed_t cur_x,
+                          twin_fixed_t cur_y,
+                          twin_fixed_t target_x,
+                          twin_fixed_t target_y);
 
 void twin_path_rectangle(twin_path_t *path,
                          twin_fixed_t x,
@@ -1103,6 +1124,10 @@ twin_fixed_t twin_cos(twin_angle_t a);
 twin_fixed_t twin_tan(twin_angle_t a);
 
 void twin_sincos(twin_angle_t a, twin_fixed_t *sin, twin_fixed_t *cos);
+
+twin_angle_t twin_atan2(twin_fixed_t y, twin_fixed_t x);
+
+twin_angle_t twin_acos(twin_fixed_t x);
 
 /*
  * widget.c

--- a/include/twin.h
+++ b/include/twin.h
@@ -1061,6 +1061,12 @@ void twin_path_curve(twin_path_t *path,
                      twin_fixed_t x3,
                      twin_fixed_t y3);
 
+void twin_path_quadratic_curve(twin_path_t *path,
+                               twin_fixed_t x1,
+                               twin_fixed_t y1,
+                               twin_fixed_t x2,
+                               twin_fixed_t y2);
+
 /*
  * timeout.c
  */

--- a/src/fixed.c
+++ b/src/fixed.c
@@ -18,6 +18,8 @@
  */
 #define CHECK_INTERVAL(x, minx, epsilon) \
     ((int32_t) ((x - (minx - epsilon)) | (minx + epsilon - x)) > 0)
+#define CHECK_INTERVAL_64(x, minx, epsilon) \
+    ((int64_t) ((x - (minx - epsilon)) | (minx + epsilon - x)) > 0)
 
 twin_fixed_t twin_fixed_sqrt(twin_fixed_t a)
 {
@@ -77,5 +79,44 @@ twin_sfixed_t _twin_sfixed_sqrt(twin_sfixed_t as)
             as -= b, z += m;
     }
 
+    return (offset >= 0) ? z >> offset : z << (-offset);
+}
+
+twin_xfixed_t _twin_xfixed_sqrt(twin_xfixed_t a)
+{
+    /* Early return for non-positive inputs */
+    if (a <= 0)
+        return 0;
+
+    /* Special case for values very close to 1 */
+    if (CHECK_INTERVAL_64(a, TWIN_XFIXED_ONE, (1ULL << (16 - 1))))
+        return TWIN_XFIXED_ONE;
+
+    /* Count leading zero bits to normalize the input */
+    int64_t offset = 0;
+    for (twin_xfixed_t i = a; !(UINT64_C(0x4000000000000000) & i); i <<= 1)
+        ++offset;
+
+    /* Ensure even offset for precision */
+    offset &= ~1;
+
+    /* Shift left to expand precision */
+    a <<= offset;
+
+    /* Calculate scaling offset */
+    offset >>= 1;
+    offset -= (32 >> 1);
+
+    /* Digit-by-digit square root calculation */
+    twin_xfixed_t z = 0;
+    for (twin_xfixed_t m = 1ULL << ((63 - __builtin_clzll(a)) & ~1ULL); m;
+         m >>= 2) {
+        twin_xfixed_t b = z + m;
+        z >>= 1;
+        if (a >= b)
+            a -= b, z += m;
+    }
+
+    /* Shift back the expanded digits */
     return (offset >= 0) ? z >> offset : z << (-offset);
 }

--- a/src/spline.c
+++ b/src/spline.c
@@ -164,3 +164,32 @@ void twin_path_curve(twin_path_t *path,
                              _twin_matrix_x(&path->state.matrix, x3, y3),
                              _twin_matrix_y(&path->state.matrix, x3, y3));
 }
+
+void twin_path_quadratic_curve(twin_path_t *path,
+                               twin_fixed_t x1,
+                               twin_fixed_t y1,
+                               twin_fixed_t x2,
+                               twin_fixed_t y2)
+{
+    /* Convert quadratic to cubic control point */
+    twin_spoint_t p0 = _twin_path_current_spoint(path);
+    twin_sfixed_t x1s = _twin_matrix_x(&path->state.matrix, x1, y1);
+    twin_sfixed_t y1s = _twin_matrix_y(&path->state.matrix, x1, y1);
+    twin_sfixed_t x2s = _twin_matrix_x(&path->state.matrix, x2, y2);
+    twin_sfixed_t y2s = _twin_matrix_y(&path->state.matrix, x2, y2);
+    /* CP1 = P0 + 2/3 * (P1 - P0) */
+    twin_sfixed_t dx1 = x1s - p0.x;
+    twin_sfixed_t dy1 = y1s - p0.y;
+    twin_sfixed_t cx1 =
+        p0.x + twin_sfixed_mul(twin_double_to_sfixed(2.0 / 3.0), dx1);
+    twin_sfixed_t cy1 =
+        p0.y + twin_sfixed_mul(twin_double_to_sfixed(2.0 / 3.0), dy1);
+    /* CP2 = P2 + 2/3 * (P1 - P2) */
+    twin_sfixed_t dx2 = x1s - x2s;
+    twin_sfixed_t dy2 = y1s - y2s;
+    twin_sfixed_t cx2 =
+        x2s + twin_sfixed_mul(twin_double_to_sfixed(2.0 / 3.0), dx2);
+    twin_sfixed_t cy2 =
+        y2s + twin_sfixed_mul(twin_double_to_sfixed(2.0 / 3.0), dy2);
+    _twin_path_scurve(path, cx1, cy1, cx2, cy2, x2s, y2s);
+}


### PR DESCRIPTION
Add missing path functionalities required for rendering TinyVG (Tiny Vector Graphics) images. Specifically, the following features have been implemented:
- Arc Ellipse
Draws an ellipse segment between the current and the target point, where `radius_x` and `radius_y` determine the both radii of the ellipse.  `large_arc` determine small(0) or larger(1) circle segment is drawn. If `sweep` is 1, the ellipse segment will make a left turn, otherwise it will make a right turn. `rotation` is the rotation of the ellipse.
- Arc circle
Draws an ellipse segment between the current and the target point, where `radius` determine the radius of the circle.  `large_arc` determine small(0) or larger(1) circle segment is drawn. If `sweep` is 1, the circle segment will make a left turn, otherwise it will make a right turn.
- Quadratic Bézier
 Draws a Bézier curve with a single control point.


### Demo
- Ellipse arc
<img width="402" alt="image" src="https://github.com/user-attachments/assets/49737fe6-9e63-4b98-904e-bc63fd31c9c8">

- Quadratic Bezier

https://github.com/user-attachments/assets/839f3bfe-125e-4064-ba4c-3f9cc6334385




Ref:
[1]:https://fontforge.org/docs/techref/bezier.html#converting-truetype-to-postscript
[2]:https://www.w3.org/TR/SVG/implnote.html