### PR TITLE
Support VT switching for fbdev backend

### DIFF
--- a/backend/linux_vt.h
+++ b/backend/linux_vt.h
@@ -10,11 +10,19 @@
 #include <fcntl.h>
 #include <linux/kd.h>
 #include <linux/vt.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include "twin_private.h"
 
 #define VT_DEV_TTY_MAX 11
+#define SIG_SWITCH_FROM SIGUSR1
+#define SIG_SWITCH_TO SIGUSR2
+
+static volatile sig_atomic_t *vt_fd;
+
+static volatile sig_atomic_t *is_vt_actived;
+
 static inline int twin_vt_open(int vt_num)
 {
     int fd;
@@ -35,7 +43,42 @@ static inline int twin_vt_mode(int fd, int mode)
     return ioctl(fd, KDSETMODE, mode);
 }
 
-static inline bool twin_vt_setup(int *fd_ptr)
+static void twin_vt_process_switch_signal(int signum)
+{
+    if (signum == SIG_SWITCH_FROM) {
+        /* Notify kernel to release current virtual terminal */
+        ioctl(*vt_fd, VT_RELDISP, 1);
+
+        /* Set the virtual terminal display in text mode */
+        ioctl(*vt_fd, KDSETMODE, KD_TEXT);
+
+        *is_vt_actived = true;
+    } else if (signum == SIG_SWITCH_TO) {
+        /* Switch complete */
+        ioctl(*vt_fd, VT_RELDISP, VT_ACKACQ);
+
+        /* Restore the virtual terminal display in graphics mode */
+        ioctl(*vt_fd, KDSETMODE, KD_GRAPHICS);
+
+        *is_vt_actived = false;
+    }
+}
+
+static inline void twin_vt_setup_signal_handler()
+{
+    struct sigaction tty_sig = {.sa_handler = twin_vt_process_switch_signal};
+    sigfillset(&tty_sig.sa_mask);
+
+    /* Set the signal handler for leaving the current TTY */
+    sigaction(SIG_SWITCH_FROM, &tty_sig, NULL);
+
+    /* Set the signal handler for returning to the previous TTY */
+    sigaction(SIG_SWITCH_TO, &tty_sig, NULL);
+}
+
+static inline bool twin_vt_setup(int *fd_ptr,
+                                 struct vt_mode *old_vtm,
+                                 bool *vt_active)
 {
     /* Open VT0 to inquire information */
     if ((*fd_ptr = twin_vt_open(0)) < -1) {
@@ -57,11 +100,42 @@ static inline bool twin_vt_setup(int *fd_ptr)
         return false;
     }
 
-    /* Set VT to graphics mode to inhibit command-line text */
-    if (twin_vt_mode(*fd_ptr, KD_GRAPHICS) < 0) {
-        log_error("Failed to set KD_GRAPHICS mode");
+    /* Attempt to activate the specified virtual terminal by its number */
+    if (ioctl(*fd_ptr, VT_ACTIVATE, vt_num) < 0) {
+        log_error("Failed to activate VT %d", vt_num);
         return false;
     }
+
+    /* Wait until the specified virtual terminal becomes the active VT */
+    if (ioctl(*fd_ptr, VT_WAITACTIVE, vt_num) < 0) {
+        log_error("Failed to activate VT %d", vt_num);
+        return false;
+    }
+
+    /* Save the virtual terminal mode */
+    if (ioctl(*fd_ptr, VT_GETMODE, &old_vtm) < 0) {
+        log_error("Failed to get VT mode");
+        return false;
+    }
+
+    /* Set the virtual terminal mode */
+    struct vt_mode vtm = {
+        .mode = VT_PROCESS, .relsig = SIGUSR1, .acqsig = SIGUSR2};
+
+    if (ioctl(*fd_ptr, VT_SETMODE, &vtm) < 0) {
+        log_error("Failed to set VT mode");
+        return false;
+    }
+
+    /* Set the virtual terminal display mode to graphics mode */
+    if (twin_vt_mode(*fd_ptr, KD_GRAPHICS) < 0) {
+        log_error("Failed to set KD_GRAPHICS mode");
+        twin_vt_mode(*fd_ptr, KD_TEXT);
+        return false;
+    }
+
+    vt_fd = fd_ptr;
+    is_vt_actived = vt_active;
 
     return true;
 }


### PR DESCRIPTION
The fbdev backend supports framebuffer rendering on a specifiend VT. To enhancce its compatibility in environments with multiple TTYs, the following improvements ensure that each framebuffer device operates independently on its own VT without affecting others.

- Implement signal handlers to manage virtual terminal switching.
- Pause screen rendering when switching to another VT.
- Resume screen rendering when switching back to the original VT.