### PR TITLE
Fix widgets not updating with parent's widget

### DIFF
--- a/apps/spline.c
+++ b/apps/spline.c
@@ -129,6 +129,7 @@ static twin_dispatch_result_t _apps_spline_update_pos(apps_spline_t *spline,
     spline->points[spline->which].y = twin_sfixed_to_fixed(
         _twin_matrix_y(&(spline->inverse_transition), x, y));
     _twin_widget_queue_paint(&spline->widget);
+    twin_widget_children_paint((spline->widget).parent);
     return TwinDispatchDone;
 }
 

--- a/include/twin.h
+++ b/include/twin.h
@@ -1124,6 +1124,9 @@ twin_angle_t twin_acos(twin_fixed_t x);
  * widget.c
  */
 
+/* Paint the widget children of the box. */
+void twin_widget_children_paint(twin_box_t *box);
+
 twin_widget_t *twin_widget_create(twin_box_t *parent,
                                   twin_argb32_t background,
                                   twin_coord_t width,

--- a/src/box.c
+++ b/src/box.c
@@ -163,6 +163,7 @@ twin_dispatch_result_t _twin_box_dispatch(twin_widget_t *widget,
     case TwinEventConfigure:
         return _twin_box_configure(box);
     case TwinEventButtonDown:
+        twin_window_show(widget->window);
         box->button_down =
             _twin_box_xy_to_widget(box, event->u.pointer.x, event->u.pointer.y);
         if (box->button_down && box->button_down->want_focus)

--- a/src/widget.c
+++ b/src/widget.c
@@ -200,6 +200,13 @@ void _twin_widget_bevel(twin_widget_t *widget, twin_fixed_t b, bool down)
     }
 }
 
+void twin_widget_children_paint(twin_box_t *box)
+{
+    /* Paint the widget children of the box. */
+    for (twin_widget_t *child = box->children; child; child = child->next)
+        _twin_widget_queue_paint(child);
+}
+
 twin_widget_t *twin_widget_create(twin_box_t *parent,
                                   twin_argb32_t background,
                                   twin_coord_t width,


### PR DESCRIPTION
Implement the twin_widget_children_paint function to repaint all the box's widgets. The issue arises when the spline updates the pixmap beneath the button widget, the pixmap of the button isn't triggered to repaint. To solve this, we call the twin_widget_paint function after the spline update to ensure the related widget will be repainted.