### PR TITLE
Fix active window not working on the framebuffer

### DIFF
--- a/apps/main.c
+++ b/apps/main.c
@@ -132,6 +132,7 @@ int main(void)
     apps_image_start(tx->screen, "Viewer", 20, 20);
 #endif
 
+    twin_screen_set_active(tx->screen, tx->screen->top);
     twin_dispatch(tx);
 
     return 0;

--- a/src/screen.c
+++ b/src/screen.c
@@ -151,25 +151,6 @@ static void twin_screen_span_pixmap(twin_screen_t maybe_unused *screen,
         op32(dst, src, p_right - p_left);
 }
 
-static twin_pixmap_t *twin_active_pixmap(twin_screen_t *screen,
-                                         twin_pixmap_t **active_pix)
-{
-    twin_pixmap_t *p = NULL, *prev_active_pix = NULL;
-    /*
-     * Identify the previously active pixel map and the currently active pixel
-     * map, which is on the topmost layer.
-     */
-    for (p = screen->bottom; p; p = p->up) {
-        if (p->window->active == true) {
-            prev_active_pix = p;
-            prev_active_pix->window->active = false;
-        }
-        (*active_pix) = p;
-    }
-    (*active_pix)->window->active = true;
-    return prev_active_pix;
-}
-
 void twin_screen_update(twin_screen_t *screen)
 {
     twin_coord_t left = screen->damage.left;
@@ -189,7 +170,7 @@ void twin_screen_update(twin_screen_t *screen)
 
     if (!screen->disable && left < right && top < bottom) {
         twin_argb32_t *span;
-        twin_pixmap_t *p, *active_pix = NULL, *prev_active_pix = NULL;
+        twin_pixmap_t *p;
         twin_coord_t y;
         twin_coord_t width = right - left;
 
@@ -202,24 +183,6 @@ void twin_screen_update(twin_screen_t *screen)
 
         if (screen->put_begin)
             (*screen->put_begin)(left, top, right, bottom, screen->closure);
-
-        prev_active_pix = twin_active_pixmap(screen, &active_pix);
-
-        /*
-         * Mark the previously active pixel map as damaged to update its
-         * changes.
-         */
-        if (prev_active_pix && active_pix != prev_active_pix) {
-            twin_pixmap_damage(prev_active_pix, 0, 0, prev_active_pix->width,
-                               prev_active_pix->height);
-            twin_window_draw(prev_active_pix->window);
-        }
-
-        /* Mark the active pixel map as damaged to update its changes. */
-        twin_pixmap_damage(active_pix, 0, 0, active_pix->width,
-                           active_pix->height);
-        twin_window_draw(active_pix->window);
-
         for (y = top; y < bottom; y++) {
             if (screen->background) {
                 twin_pointer_t dst;

--- a/src/window.c
+++ b/src/window.c
@@ -387,6 +387,20 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
 
     switch (ev.kind) {
     case TwinEventButtonDown:
+    case TwinEventActivate:
+        /* Set window active. */
+        /*
+         * When the box is trigger by TwinEventButtonDown, its window's title
+         * bar needs to change color and be put onto the toppest layer.
+         */
+        if (!window->active) {
+            window->active = true;
+            twin_window_frame(window);
+            if (window != window->screen->top->window) {
+                window->screen->top->window->active = false;
+                twin_window_frame(window->screen->top->window);
+            }
+        }
         if (window->client.left <= ev.u.pointer.x &&
             ev.u.pointer.x < window->client.right &&
             window->client.top <= ev.u.pointer.y &&


### PR DESCRIPTION
Remove the inefficiently function twin_active_pixmap(). This function finds the currently and previously active window pixel map by traversing the list of pixel maps. This function will be called every time the screen needs to be updated. Set the active variable of the window only when the window's event TwinEventButtonDown is triggered to avoid redundant operations. Additionally, implement the function twin_window_active_paint() to only repaint the title bar instead of calling the function twin_window_draw() to indirectly call the function twin_window_frame to repaint the title bar of the window.

Close #92