### PR TITLE
Change the logic for window click detection

### DIFF
--- a/include/twin.h
+++ b/include/twin.h
@@ -1161,9 +1161,14 @@ void twin_window_configure(twin_window_t *window,
                            twin_coord_t width,
                            twin_coord_t height);
 
-void twin_window_set_name(twin_window_t *window, const char *name);
+/* Check if the coordinates are within the window's range. */
+bool twin_window_valid_range(twin_window_t *window,
+                             twin_coord_t x,
+                             twin_coord_t y);
 
 void twin_window_style_size(twin_window_style_t style, twin_rect_t *size);
+
+void twin_window_set_name(twin_window_t *window, const char *name);
 
 void twin_window_draw(twin_window_t *window);
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -381,8 +381,9 @@ bool twin_screen_dispatch(twin_screen_t *screen, twin_event_t *event)
 
         /* check who the mouse is over now */
         for (ntarget = screen->top; ntarget; ntarget = ntarget->down)
-            if (!twin_pixmap_transparent(ntarget, event->u.pointer.screen_x,
-                                         event->u.pointer.screen_y))
+            if (twin_window_valid_range(ntarget->window,
+                                        event->u.pointer.screen_x,
+                                        event->u.pointer.screen_y))
                 break;
 
         /* ah, somebody new ... send leave/enter events and set new target */

--- a/src/window.c
+++ b/src/window.c
@@ -132,6 +132,32 @@ void twin_window_configure(twin_window_t *window,
     twin_pixmap_enable_update(window->pixmap);
 }
 
+bool twin_window_valid_range(twin_window_t *window,
+                             twin_coord_t x,
+                             twin_coord_t y)
+{
+    switch (window->style) {
+    case TwinWindowPlain:
+    default:
+        if (window->pixmap->x <= x &&
+            x < window->pixmap->x + window->pixmap->width &&
+            window->pixmap->y <= y &&
+            y < window->pixmap->y + window->pixmap->height)
+            return true;
+        return false;
+    case TwinWindowApplication:
+        if (window->pixmap->x <= x &&
+            x < window->pixmap->x + window->pixmap->width &&
+            window->pixmap->y <= y &&
+            y < window->pixmap->y + window->pixmap->height) {
+            if (y < window->pixmap->y + (window->client.top))
+                return !twin_pixmap_transparent(window->pixmap, x, y);
+            return true;
+        }
+        return false;
+    }
+}
+
 void twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
 {
     switch (style) {


### PR DESCRIPTION
Implement the function twin_window_valid_range() to check whether the click coordinates fall within the window's range, based on the window's style. Originally, the logic for detecting if the window was clicked relied on the function twin_pixmap_transparent(). However, the click event won't be triggered when a transparent pixel in the window's region is clicked.