### PR TITLE
Fix missing -pthread for fbdev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 
 ifeq ($(CONFIG_BACKEND_FBDEV), y)
 BACKEND = fbdev
-TARGET_LIBS += -ludev
+TARGET_LIBS += -ludev -pthread
 libtwin.a_files-y += backend/fbdev.c
 libtwin.a_files-y += backend/linux_input.c
 endif


### PR DESCRIPTION
Since pthread is explicitly used in `linux_input.c` (which is used in builds for fbdev), it is necessary to add pthread to the `TARGET_LIBS` list to ensure the build completes successfully.