### PR TITLE
Fix the cursor position

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -116,7 +116,7 @@ twin_pixmap_t *twin_make_cursor(int *hx, int *hy)
         twin_pixmap_create_const(TWIN_ARGB32, 14, 20, 14 * 4, pixels);
     if (!cur)
         return NULL;
-    *hx = 14;
-    *hy = 20;
+    *hx = 0;
+    *hy = 0;
     return cur;
 }


### PR DESCRIPTION
The coordinates (x,y) of the cursor should not be set to the cursor's width (14) and height (20). Instead, the coordinates should be set to (0,0), ensuring that the cursor's hotspot is correctly aligned at the intended position. 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the cursor positioning logic by updating the coordinates from (14,20) to (0,0). This adjustment ensures the cursor's hotspot is correctly aligned, enhancing the overall user experience.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>