### PR TITLE
Add iconify and restore features on window frame

### DIFF
--- a/include/twin.h
+++ b/include/twin.h
@@ -443,6 +443,7 @@ struct _twin_window {
     twin_rect_t client;
     twin_rect_t damage;
     bool active;
+    bool iconify;
     bool client_grab;
     bool want_focus;
     bool draw_queued;
@@ -459,8 +460,8 @@ struct _twin_window {
  */
 typedef enum _twin_icon {
     TwinIconMenu,
-    TwinIconMinimize,
-    TwinIconMaximize,
+    TwinIconIconify,
+    TwinIconRestore,
     TwinIconClose,
     TwinIconResize,
 } twin_icon_t;

--- a/src/draw-common.c
+++ b/src/draw-common.c
@@ -163,12 +163,17 @@ void twin_shadow_border(twin_pixmap_t *shadow,
                  offset = min(offset_x, offset_y);
 
     switch (shadow->window->style) {
+    /*
+     * Draw a black border starting from the top y position of the window's
+     * client area plus CONFIG_SHADOW_BLUR / 2 + 1, to prevent twin_stack_blur()
+     * from blurring shadows over the window frame.
+     */
     case TwinWindowApplication:
-        y_start = TWIN_TITLE_HEIGHT;
+        y_start = TWIN_TITLE_HEIGHT + CONFIG_SHADOW_BLUR / 2 + 1;
         break;
     case TwinWindowPlain:
     default:
-        y_start = 0;
+        y_start = CONFIG_SHADOW_BLUR / 2 + 1;
         break;
     }
 

--- a/src/icon.c
+++ b/src/icon.c
@@ -39,8 +39,8 @@ static const signed char _twin_itable[] = {
     's',
     'e',
 #define TWIN_MENU_LEN	    43
-    /* Minimize */
-#define TWIN_MINIMIZE_POS   TWIN_MENU_POS + TWIN_MENU_LEN
+    /* Iconify */
+#define TWIN_ICONIFY_POS   TWIN_MENU_POS + TWIN_MENU_LEN
     'm', L(0), G(0.8),
     'd', L(0), B(1),
     'd', R(1), B(1),
@@ -49,9 +49,9 @@ static const signed char _twin_itable[] = {
     'w', G(0.05),
     'p',
     'e',
-#define TWIN_MINIMIZE_LEN   17
-    /* Maximize */
-#define TWIN_MAXIMIZE_POS   TWIN_MINIMIZE_POS + TWIN_MINIMIZE_LEN
+#define TWIN_ICONIFY_LEN   17
+    /* Restore */
+#define TWIN_RESTORE_POS   TWIN_ICONIFY_POS + TWIN_ICONIFY_LEN
     'm', L(0), T(0),
     'd', L(0), G(0.2),
     'd', R(1), G(0.2),
@@ -64,9 +64,9 @@ static const signed char _twin_itable[] = {
     'x',
     's',
     'e',
-#define TWIN_MAXIMIZE_LEN   28
+#define TWIN_RESTORE_LEN   28
     /* Close */
-#define TWIN_CLOSE_POS	    TWIN_MAXIMIZE_POS + TWIN_MAXIMIZE_LEN
+#define TWIN_CLOSE_POS	    TWIN_RESTORE_POS + TWIN_RESTORE_LEN
     'm', L(0), T(0),
     'd', L(0), T(0.1),
     'd', G(0.4), G(0.5),
@@ -103,7 +103,7 @@ static const signed char _twin_itable[] = {
 /* clang-format on */
 
 const uint16_t _twin_icons[] = {
-    TWIN_MENU_POS,  TWIN_MINIMIZE_POS, TWIN_MAXIMIZE_POS,
+    TWIN_MENU_POS,  TWIN_ICONIFY_POS, TWIN_RESTORE_POS,
     TWIN_CLOSE_POS, TWIN_RESIZE_POS,
 };
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -9,6 +9,9 @@
 
 #include "twin_private.h"
 
+#define TWIN_BW 0
+#define TWIN_TITLE_HEIGHT 20
+
 twin_screen_t *twin_screen_create(twin_coord_t width,
                                   twin_coord_t height,
                                   twin_put_begin_t put_begin,
@@ -135,6 +138,11 @@ static void twin_screen_span_pixmap(twin_screen_t maybe_unused *screen,
         return;
     if (p->y + p->height <= y)
         return;
+
+    /* Skip drawing the window's client area if the window is iconified. */
+    if (p->window->iconify && y >= p->y + TWIN_BW + TWIN_TITLE_HEIGHT + TWIN_BW)
+        return;
+
     /* bounds check in x */
     p_left = left;
     if (p_left < p->x)


### PR DESCRIPTION
This pull request introduces iconify and restore functionality for windows.
It also updates the logic for determining when a window is considered active.
The window frame now changes to blue only when the window is not iconified and is the topmost window. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the window management system by introducing minimize and maximize functionality, along with an iconify property in the window structure. It updates the drawing logic to reflect the active state of windows based on their minimized status, changing the window frame color accordingly.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively simple.
-->
</div>