### PR TITLE
Fix iconified pixmap check condition

### DIFF
--- a/include/twin.h
+++ b/include/twin.h
@@ -1036,6 +1036,8 @@ bool twin_pixmap_transparent(twin_pixmap_t *pixmap,
                              twin_coord_t x,
                              twin_coord_t y);
 
+bool twin_pixmap_is_iconified(twin_pixmap_t *pixmap, twin_coord_t y);
+
 bool twin_pixmap_dispatch(twin_pixmap_t *pixmap, twin_event_t *event);
 
 /*

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -9,6 +9,9 @@
 
 #include "twin_private.h"
 
+#define TWIN_BW 0
+#define TWIN_TITLE_HEIGHT 20
+
 #define IS_ALIGNED(p, alignment) ((p % alignment) == 0)
 #define ALIGN_UP(sz, alignment)                            \
     (((alignment) & ((alignment) - 1)) == 0                \
@@ -316,6 +319,19 @@ bool twin_pixmap_transparent(twin_pixmap_t *pixmap,
                              twin_coord_t y)
 {
     return (_twin_pixmap_fetch(pixmap, x, y) >> 24) == 0;
+}
+
+bool twin_pixmap_is_iconified(twin_pixmap_t *pixmap, twin_coord_t y)
+{
+    /*
+     * Check whether the specified area within the pixmap corresponds to an
+     * iconified window.
+     */
+    if (pixmap->window &&
+        (pixmap->window->iconify &&
+         y >= pixmap->y + TWIN_BW + TWIN_TITLE_HEIGHT + TWIN_BW))
+        return true;
+    return false;
 }
 
 void twin_pixmap_move(twin_pixmap_t *pixmap, twin_coord_t x, twin_coord_t y)


### PR DESCRIPTION
Add twin_pixmap_iconify() function to determine whether a pixmap is iconified. This function provides a way to access the corresponding window's iconify state, after verifying that the pixmap belongs to a window. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces the function twin_pixmap_is_iconified, which checks if a pixmap is iconified based on its window state. It also updates the pixmap and screen files to allow drawing operations to bypass iconified pixmaps, enhancing window state handling in the graphical interface.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve adding a new function and updating existing files, making the review process relatively simple.
-->
</div>