### PR TITLE
Fix Inaccurate Window Movement in Linux Framebuffer Backend

### DIFF
--- a/backend/fbdev.c
+++ b/backend/fbdev.c
@@ -190,7 +190,8 @@ static bool twin_fbdev_update_damage(void *closure)
     twin_fbdev_t *tx = PRIV(closure);
     twin_screen_t *screen = SCREEN(closure);
 
-    if (!tx->vt_active && twin_screen_damaged(screen))
+    if (!tx->vt_active && (tx->fb_base == MAP_FAILED) &&
+        twin_screen_damaged(screen))
         twin_screen_update(screen);
 
     return true;


### PR DESCRIPTION
Windows would jump to unexpected positions when moving with the mouse on the Linux framebuffer backend. This patch, tested on Raspberry Pi 3B and virtual machines, ensures smoother and more reliable window dragging behavior. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the Linux framebuffer backend that caused windows to jump during mouse movement. It improves window dragging behavior on Raspberry Pi 3B by modifying screen update conditions, enhancing user experience.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on bug fixes, making the review process relatively simple.
-->
</div>