### PR TITLE
Implement public custom widget API

### DIFF
--- a/apps/image.c
+++ b/apps/image.c
@@ -6,20 +6,24 @@
 
 #include <stdlib.h>
 
-#include "twin_private.h"
+#include <twin.h>
 
 #include "apps_image.h"
 
-#define _apps_image_pixmap(image) ((image)->widget.window->pixmap)
+static inline twin_pixmap_t *_apps_image_pixmap(twin_custom_widget_t *image)
+{
+    return twin_custom_widget_pixmap(image);
+}
+
 #define D(x) twin_double_to_fixed(x)
 #define ASSET_PATH "assets/"
 #define APP_WIDTH 400
 #define APP_HEIGHT 400
+
 typedef struct {
-    twin_widget_t widget;
     twin_pixmap_t **pixes;
     int image_idx;
-} apps_image_t;
+} apps_image_data_t;
 
 static const char *tvg_files[] = {
     /* https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ */
@@ -36,26 +40,29 @@ static const char *tvg_files[] = {
     ASSET_PATH "flowchart.tvg",
 };
 
-static void _apps_image_paint(apps_image_t *img)
+static void _apps_image_paint(twin_custom_widget_t *custom)
 {
+    apps_image_data_t *img =
+        (apps_image_data_t *) twin_custom_widget_data(custom);
     twin_operand_t srcop = {
         .source_kind = TWIN_PIXMAP,
         .u.pixmap = img->pixes[img->image_idx],
     };
 
-    twin_composite(_apps_image_pixmap(img), 0, 0, &srcop, 0, 0, NULL, 0, 0,
+    twin_composite(_apps_image_pixmap(custom), 0, 0, &srcop, 0, 0, NULL, 0, 0,
                    TWIN_SOURCE, APP_WIDTH, APP_HEIGHT);
 }
 
 static twin_dispatch_result_t _apps_image_dispatch(twin_widget_t *widget,
                                                    twin_event_t *event)
 {
-    apps_image_t *img = (apps_image_t *) widget;
-    if (_twin_widget_dispatch(widget, event) == TwinDispatchDone)
-        return TwinDispatchDone;
+    twin_custom_widget_t *custom = twin_widget_get_custom(widget);
+    if (!custom)
+        return TwinDispatchContinue;
+
     switch (event->kind) {
     case TwinEventPaint:
-        _apps_image_paint(img);
+        _apps_image_paint(custom);
         break;
     default:
         break;
@@ -63,14 +70,17 @@ static twin_dispatch_result_t _apps_image_dispatch(twin_widget_t *widget,
     return TwinDispatchContinue;
 }
 
-static void _apps_image_button_signal(maybe_unused twin_button_t *button,
+static void _apps_image_button_signal(twin_button_t *button,
                                       twin_button_signal_t signal,
                                       void *closure)
 {
+    (void) button; /* unused parameter */
     if (signal != TwinButtonSignalDown)
         return;
 
-    apps_image_t *img = closure;
+    twin_custom_widget_t *custom = closure;
+    apps_image_data_t *img =
+        (apps_image_data_t *) twin_custom_widget_data(custom);
     const int n = sizeof(tvg_files) / sizeof(tvg_files[0]);
     img->image_idx = img->image_idx == n - 1 ? 0 : img->image_idx + 1;
     if (!img->pixes[img->image_idx]) {
@@ -80,35 +90,39 @@ static void _apps_image_button_signal(maybe_unused twin_button_t *button,
             return;
         img->pixes[img->image_idx] = pix;
     }
-    _twin_widget_queue_paint(&img->widget);
+    twin_custom_widget_queue_paint(custom);
 }
 
-static void _apps_image_init(apps_image_t *img,
-                             twin_box_t *parent,
-                             twin_dispatch_proc_t dispatch)
+static twin_custom_widget_t *_apps_image_init(twin_box_t *parent)
 {
-    static twin_widget_layout_t preferred = {0, 0, 1, 1};
-    preferred.height = parent->widget.window->screen->height * 3.0 / 4.0;
-    _twin_widget_init(&img->widget, parent, 0, preferred, dispatch);
+    twin_custom_widget_t *custom = twin_custom_widget_create(
+        parent, 0, 0, parent->widget.window->screen->height * 3 / 4, 1, 1,
+        _apps_image_dispatch, sizeof(apps_image_data_t));
+    if (!custom)
+        return NULL;
+
+    apps_image_data_t *img =
+        (apps_image_data_t *) twin_custom_widget_data(custom);
     img->image_idx = 0;
-    img->pixes = calloc(sizeof(tvg_files), sizeof(twin_pixmap_t *));
+    img->pixes = calloc(sizeof(tvg_files) / sizeof(tvg_files[0]),
+                        sizeof(twin_pixmap_t *));
     img->pixes[0] = twin_tvg_to_pixmap_scale(tvg_files[0], TWIN_ARGB32,
                                              APP_WIDTH, APP_HEIGHT);
+
     twin_button_t *button =
         twin_button_create(parent, "Next Image", 0xFF482722, D(10),
                            TwinStyleBold | TwinStyleOblique);
     twin_widget_set(&button->label.widget, 0xFFFEE4CE);
     button->signal = _apps_image_button_signal;
-    button->closure = img;
+    button->closure = custom;
     button->label.widget.shape = TwinShapeRectangle;
+
+    return custom;
 }
 
-static apps_image_t *apps_image_create(twin_box_t *parent)
+static twin_custom_widget_t *apps_image_create(twin_box_t *parent)
 {
-    apps_image_t *img = malloc(sizeof(apps_image_t));
-
-    _apps_image_init(img, parent, _apps_image_dispatch);
-    return img;
+    return _apps_image_init(parent);
 }
 
 void apps_image_start(twin_screen_t *screen, const char *name, int x, int y)
@@ -116,7 +130,7 @@ void apps_image_start(twin_screen_t *screen, const char *name, int x, int y)
     twin_toplevel_t *toplevel =
         twin_toplevel_create(screen, TWIN_ARGB32, TwinWindowApplication, x, y,
                              APP_WIDTH, APP_HEIGHT, name);
-    apps_image_t *img = apps_image_create(&toplevel->box);
+    twin_custom_widget_t *img = apps_image_create(&toplevel->box);
     (void) img;
     twin_toplevel_show(toplevel);
 }

--- a/apps/line.c
+++ b/apps/line.c
@@ -7,50 +7,59 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "twin_private.h"
+#include <twin.h>
 
 #include "apps_line.h"
 
 #define D(x) twin_double_to_fixed(x)
 
-#define _apps_line_pixmap(line) ((line)->widget.window->pixmap)
+static inline twin_pixmap_t *_apps_line_pixmap(twin_custom_widget_t *line)
+{
+    return twin_custom_widget_pixmap(line);
+}
 
-typedef struct _apps_line {
-    twin_widget_t widget;
+typedef struct {
     twin_point_t points[2];
     int which;
     twin_fixed_t line_width;
     twin_cap_t cap_style;
-} apps_line_t;
+} apps_line_data_t;
 
-static void _apps_line_paint(apps_line_t *line)
+static void _apps_line_paint(twin_custom_widget_t *custom)
 {
+    apps_line_data_t *line =
+        (apps_line_data_t *) twin_custom_widget_data(custom);
     twin_path_t *path;
 
     path = twin_path_create();
     twin_path_set_cap_style(path, line->cap_style);
     twin_path_move(path, line->points[0].x, line->points[0].y);
     twin_path_draw(path, line->points[1].x, line->points[1].y);
-    twin_paint_stroke(_apps_line_pixmap(line), 0xff000000, path,
+    twin_paint_stroke(_apps_line_pixmap(custom), 0xff000000, path,
                       line->line_width);
     twin_path_set_cap_style(path, TwinCapButt);
-    twin_paint_stroke(_apps_line_pixmap(line), 0xffff0000, path,
+    twin_paint_stroke(_apps_line_pixmap(custom), 0xffff0000, path,
                       twin_int_to_fixed(2));
     twin_path_destroy(path);
 }
 
-static twin_dispatch_result_t _apps_line_update_pos(apps_line_t *line,
-                                                    twin_event_t *event)
+static twin_dispatch_result_t _apps_line_update_pos(
+    twin_custom_widget_t *custom,
+    twin_event_t *event)
 {
+    apps_line_data_t *line =
+        (apps_line_data_t *) twin_custom_widget_data(custom);
     if (line->which < 0)
         return TwinDispatchContinue;
     line->points[line->which].x = twin_int_to_fixed(event->u.pointer.x);
     line->points[line->which].y = twin_int_to_fixed(event->u.pointer.y);
-    _twin_widget_queue_paint(&line->widget);
+    twin_custom_widget_queue_paint(custom);
     return TwinDispatchDone;
 }
 
-static int _apps_line_hit(apps_line_t *line, twin_fixed_t x, twin_fixed_t y)
+static int _apps_line_hit(apps_line_data_t *line,
+                          twin_fixed_t x,
+                          twin_fixed_t y)
 {
     int i;
 
@@ -64,27 +73,30 @@ static int _apps_line_hit(apps_line_t *line, twin_fixed_t x, twin_fixed_t y)
 static twin_dispatch_result_t _apps_line_dispatch(twin_widget_t *widget,
                                                   twin_event_t *event)
 {
-    apps_line_t *line = (apps_line_t *) widget;
+    twin_custom_widget_t *custom = twin_widget_get_custom(widget);
+    if (!custom)
+        return TwinDispatchContinue;
 
-    if (_twin_widget_dispatch(widget, event) == TwinDispatchDone)
-        return TwinDispatchDone;
+    apps_line_data_t *line =
+        (apps_line_data_t *) twin_custom_widget_data(custom);
+
     switch (event->kind) {
     case TwinEventPaint:
-        _apps_line_paint(line);
+        _apps_line_paint(custom);
         break;
     case TwinEventButtonDown:
         line->which =
             _apps_line_hit(line, twin_int_to_fixed(event->u.pointer.x),
                            twin_int_to_fixed(event->u.pointer.y));
-        return _apps_line_update_pos(line, event);
+        return _apps_line_update_pos(custom, event);
         break;
     case TwinEventMotion:
-        return _apps_line_update_pos(line, event);
+        return _apps_line_update_pos(custom, event);
         break;
     case TwinEventButtonUp:
         if (line->which < 0)
             return TwinDispatchContinue;
-        _apps_line_update_pos(line, event);
+        _apps_line_update_pos(custom, event);
         line->which = -1;
         return TwinDispatchDone;
         break;
@@ -94,27 +106,30 @@ static twin_dispatch_result_t _apps_line_dispatch(twin_widget_t *widget,
     return TwinDispatchContinue;
 }
 
-static void _apps_line_init(apps_line_t *line,
-                            twin_box_t *parent,
-                            twin_dispatch_proc_t dispatch)
+static twin_custom_widget_t *_apps_line_init(twin_box_t *parent)
 {
-    static const twin_widget_layout_t preferred = {0, 0, 1, 1};
-    _twin_widget_init(&line->widget, parent, 0, preferred, dispatch);
-    twin_widget_set(&line->widget, 0xffffffff);
+    twin_custom_widget_t *custom = twin_custom_widget_create(
+        parent, 0xffffffff, 0, 0, 1, 1, _apps_line_dispatch,
+        sizeof(apps_line_data_t));
+    if (!custom)
+        return NULL;
+
+    apps_line_data_t *line =
+        (apps_line_data_t *) twin_custom_widget_data(custom);
     line->line_width = twin_int_to_fixed(30);
     line->cap_style = TwinCapProjecting;
     line->points[0].x = twin_int_to_fixed(50);
     line->points[0].y = twin_int_to_fixed(50);
     line->points[1].x = twin_int_to_fixed(100);
     line->points[1].y = twin_int_to_fixed(100);
+    line->which = -1;
+
+    return custom;
 }
 
-static apps_line_t *apps_line_create(twin_box_t *parent)
+static twin_custom_widget_t *apps_line_create(twin_box_t *parent)
 {
-    apps_line_t *line = malloc(sizeof(apps_line_t));
-
-    _apps_line_init(line, parent, _apps_line_dispatch);
-    return line;
+    return _apps_line_init(parent);
 }
 
 void apps_line_start(twin_screen_t *screen,
@@ -126,7 +141,7 @@ void apps_line_start(twin_screen_t *screen,
 {
     twin_toplevel_t *toplevel = twin_toplevel_create(
         screen, TWIN_ARGB32, TwinWindowApplication, x, y, w, h, name);
-    apps_line_t *line = apps_line_create(&toplevel->box);
+    twin_custom_widget_t *line = apps_line_create(&toplevel->box);
     (void) line;
     twin_toplevel_show(toplevel);
 }

--- a/apps/spline.c
+++ b/apps/spline.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "twin_private.h"
+#include <twin.h>
 
 #include "apps_spline.h"
 
@@ -16,10 +16,12 @@
 #define BACKBONE_WIDTH 2
 #define AUX_LINE_WIDTH 2
 
-#define _apps_spline_pixmap(spline) ((spline)->widget.window->pixmap)
+static inline twin_pixmap_t *_apps_spline_pixmap(twin_custom_widget_t *spline)
+{
+    return twin_custom_widget_pixmap(spline);
+}
 
-typedef struct _apps_spline {
-    twin_widget_t widget;
+typedef struct {
     int n_points;
     twin_point_t *points;
     int which;
@@ -27,9 +29,9 @@ typedef struct _apps_spline {
     twin_cap_t cap_style;
     twin_matrix_t transition;
     twin_matrix_t inverse_transition;
-} apps_spline_t;
+} apps_spline_data_t;
 
-static void _init_control_point(apps_spline_t *spline)
+static void _init_control_point(apps_spline_data_t *spline)
 {
     const int init_point_quad[3][2] = {
         {100, 100},
@@ -55,19 +57,22 @@ static void _init_control_point(apps_spline_t *spline)
 }
 
 static void _draw_aux_line(twin_path_t *path,
-                           apps_spline_t *spline,
+                           twin_custom_widget_t *custom,
+                           apps_spline_data_t *spline,
                            int idx1,
                            int idx2)
 {
     twin_path_move(path, spline->points[idx1].x, spline->points[idx1].y);
     twin_path_draw(path, spline->points[idx2].x, spline->points[idx2].y);
-    twin_paint_stroke(_apps_spline_pixmap(spline), 0xc08000c0, path,
+    twin_paint_stroke(_apps_spline_pixmap(custom), 0xc08000c0, path,
                       twin_int_to_fixed(AUX_LINE_WIDTH));
     twin_path_empty(path);
 }
 
-static void _apps_spline_paint(apps_spline_t *spline)
+static void _apps_spline_paint(twin_custom_widget_t *custom)
 {
+    apps_spline_data_t *spline =
+        (apps_spline_data_t *) twin_custom_widget_data(custom);
     twin_path_t *path;
     path = twin_path_create();
     twin_path_set_cap_style(path, spline->cap_style);
@@ -83,69 +88,75 @@ static void _apps_spline_paint(apps_spline_t *spline)
                                   spline->points[1].y, spline->points[2].x,
                                   spline->points[2].y);
     }
-    twin_paint_stroke(_apps_spline_pixmap(spline), 0xff404040, path,
+    twin_paint_stroke(_apps_spline_pixmap(custom), 0xff404040, path,
                       spline->line_width);
     twin_path_set_cap_style(path, TwinCapButt);
-    twin_paint_stroke(_apps_spline_pixmap(spline), 0xffffff00, path,
+    twin_paint_stroke(_apps_spline_pixmap(custom), 0xffffff00, path,
                       twin_int_to_fixed(BACKBONE_WIDTH));
     twin_path_empty(path);
     if (spline->n_points == 4) {
-        _draw_aux_line(path, spline, 0, 1);
-        _draw_aux_line(path, spline, 3, 2);
+        _draw_aux_line(path, custom, spline, 0, 1);
+        _draw_aux_line(path, custom, spline, 3, 2);
     } else if (spline->n_points == 3) {
-        _draw_aux_line(path, spline, 0, 1);
-        _draw_aux_line(path, spline, 1, 2);
+        _draw_aux_line(path, custom, spline, 0, 1);
+        _draw_aux_line(path, custom, spline, 1, 2);
     }
 
     for (int i = 0; i < spline->n_points; i++) {
         twin_path_empty(path);
         twin_path_circle(path, spline->points[i].x, spline->points[i].y,
                          twin_int_to_fixed(CONTROL_POINT_RADIUS));
-        twin_paint_path(_apps_spline_pixmap(spline), 0x40004020, path);
+        twin_paint_path(_apps_spline_pixmap(custom), 0x40004020, path);
     }
     twin_path_destroy(path);
 }
 
-static void _apps_spline_button_signal(maybe_unused twin_button_t *button,
+static void _apps_spline_button_signal(twin_button_t *button,
                                        twin_button_signal_t signal,
                                        void *closure)
 {
+    (void) button; /* unused parameter */
     if (signal != TwinButtonSignalDown)
         return;
 
-    apps_spline_t *spline = closure;
+    twin_custom_widget_t *custom = closure;
+    apps_spline_data_t *spline =
+        (apps_spline_data_t *) twin_custom_widget_data(custom);
     spline->n_points = (spline->n_points == 3) ? 4 : 3;
     _init_control_point(spline);
-    _twin_widget_queue_paint(&spline->widget);
+    twin_custom_widget_queue_paint(custom);
 }
 
-static twin_dispatch_result_t _apps_spline_update_pos(apps_spline_t *spline,
-                                                      twin_event_t *event)
+static twin_dispatch_result_t _apps_spline_update_pos(
+    twin_custom_widget_t *custom,
+    twin_event_t *event)
 {
+    apps_spline_data_t *spline =
+        (apps_spline_data_t *) twin_custom_widget_data(custom);
     if (spline->which < 0)
         return TwinDispatchContinue;
     twin_fixed_t x = twin_int_to_fixed(event->u.pointer.x);
     twin_fixed_t y = twin_int_to_fixed(event->u.pointer.y);
 
-    spline->points[spline->which].x = twin_sfixed_to_fixed(
-        _twin_matrix_x(&(spline->inverse_transition), x, y));
-    spline->points[spline->which].y = twin_sfixed_to_fixed(
-        _twin_matrix_y(&(spline->inverse_transition), x, y));
-    _twin_widget_queue_paint(&spline->widget);
-    twin_widget_children_paint((spline->widget).parent);
+    spline->points[spline->which].x =
+        twin_matrix_transform_x(&(spline->inverse_transition), x, y);
+    spline->points[spline->which].y =
+        twin_matrix_transform_y(&(spline->inverse_transition), x, y);
+    twin_custom_widget_queue_paint(custom);
+    twin_widget_children_paint(twin_custom_widget_base(custom)->parent);
     return TwinDispatchDone;
 }
 
-static int _apps_spline_hit(apps_spline_t *spline,
+static int _apps_spline_hit(apps_spline_data_t *spline,
                             twin_fixed_t x,
                             twin_fixed_t y)
 {
     int i;
     for (i = 0; i < spline->n_points; i++) {
-        twin_fixed_t px = twin_sfixed_to_fixed(_twin_matrix_x(
-            &(spline->transition), spline->points[i].x, spline->points[i].y));
-        twin_fixed_t py = twin_sfixed_to_fixed(_twin_matrix_y(
-            &(spline->transition), spline->points[i].x, spline->points[i].y));
+        twin_fixed_t px = twin_matrix_transform_x(
+            &(spline->transition), spline->points[i].x, spline->points[i].y);
+        twin_fixed_t py = twin_matrix_transform_y(
+            &(spline->transition), spline->points[i].x, spline->points[i].y);
         if (twin_fixed_abs(x - px) < twin_int_to_fixed(CONTROL_POINT_RADIUS) &&
             twin_fixed_abs(y - py) < twin_int_to_fixed(CONTROL_POINT_RADIUS))
             return i;
@@ -156,27 +167,30 @@ static int _apps_spline_hit(apps_spline_t *spline,
 static twin_dispatch_result_t _apps_spline_dispatch(twin_widget_t *widget,
                                                     twin_event_t *event)
 {
-    apps_spline_t *spline = (apps_spline_t *) widget;
+    twin_custom_widget_t *custom = twin_widget_get_custom(widget);
+    if (!custom)
+        return TwinDispatchContinue;
 
-    if (_twin_widget_dispatch(widget, event) == TwinDispatchDone)
-        return TwinDispatchDone;
+    apps_spline_data_t *spline =
+        (apps_spline_data_t *) twin_custom_widget_data(custom);
+
     switch (event->kind) {
     case TwinEventPaint:
-        _apps_spline_paint(spline);
+        _apps_spline_paint(custom);
         break;
     case TwinEventButtonDown:
         spline->which =
             _apps_spline_hit(spline, twin_int_to_fixed(event->u.pointer.x),
                              twin_int_to_fixed(event->u.pointer.y));
-        return _apps_spline_update_pos(spline, event);
+        return _apps_spline_update_pos(custom, event);
         break;
     case TwinEventMotion:
-        return _apps_spline_update_pos(spline, event);
+        return _apps_spline_update_pos(custom, event);
         break;
     case TwinEventButtonUp:
         if (spline->which < 0)
             return TwinDispatchContinue;
-        _apps_spline_update_pos(spline, event);
+        _apps_spline_update_pos(custom, event);
         spline->which = -1;
         return TwinDispatchDone;
         break;
@@ -186,15 +200,16 @@ static twin_dispatch_result_t _apps_spline_dispatch(twin_widget_t *widget,
     return TwinDispatchContinue;
 }
 
-static void _apps_spline_init(apps_spline_t *spline,
-                              twin_box_t *parent,
-                              twin_dispatch_proc_t dispatch,
-                              int n_points)
+static twin_custom_widget_t *_apps_spline_init(twin_box_t *parent, int n_points)
 {
-    static twin_widget_layout_t preferred = {0, 0, 1, 1};
-    preferred.height = parent->widget.window->screen->height * 2 / 3;
-    _twin_widget_init(&spline->widget, parent, 0, preferred, dispatch);
-    twin_widget_set(&spline->widget, 0xffffffff);
+    twin_custom_widget_t *custom = twin_custom_widget_create(
+        parent, 0xffffffff, 0, parent->widget.window->screen->height * 2 / 3, 1,
+        1, _apps_spline_dispatch, sizeof(apps_spline_data_t));
+    if (!custom)
+        return NULL;
+
+    apps_spline_data_t *spline =
+        (apps_spline_data_t *) twin_custom_widget_data(custom);
     spline->line_width = twin_int_to_fixed(100);
     spline->cap_style = TwinCapRound;
     twin_matrix_identity(&spline->transition);
@@ -203,22 +218,24 @@ static void _apps_spline_init(apps_spline_t *spline,
     twin_matrix_rotate(&spline->inverse_transition, -TWIN_ANGLE_11_25);
     spline->points = calloc(n_points, sizeof(twin_point_t));
     spline->n_points = n_points;
+    spline->which = -1;
     _init_control_point(spline);
+
     twin_button_t *button =
         twin_button_create(parent, "Switch curve", 0xffae0000, D(10),
                            TwinStyleBold | TwinStyleOblique);
     twin_widget_set(&button->label.widget, 0xc0808080);
     button->signal = _apps_spline_button_signal;
-    button->closure = spline;
+    button->closure = custom;
     button->label.widget.shape = TwinShapeRectangle;
+
+    return custom;
 }
 
-static apps_spline_t *apps_spline_create(twin_box_t *parent, int n_points)
+static twin_custom_widget_t *apps_spline_create(twin_box_t *parent,
+                                                int n_points)
 {
-    apps_spline_t *spline = malloc(sizeof(apps_spline_t));
-
-    _apps_spline_init(spline, parent, _apps_spline_dispatch, n_points);
-    return spline;
+    return _apps_spline_init(parent, n_points);
 }
 
 void apps_spline_start(twin_screen_t *screen,
@@ -230,7 +247,7 @@ void apps_spline_start(twin_screen_t *screen,
 {
     twin_toplevel_t *toplevel = twin_toplevel_create(
         screen, TWIN_ARGB32, TwinWindowApplication, x, y, w, h, name);
-    apps_spline_t *spline = apps_spline_create(&toplevel->box, 4);
+    twin_custom_widget_t *spline = apps_spline_create(&toplevel->box, 4);
     (void) spline;
     twin_toplevel_show(toplevel);
 }

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -165,3 +165,17 @@ twin_sfixed_t _twin_matrix_len(twin_matrix_t *m,
     twin_fixed_t ds = (twin_fixed_mul(xs, xs) + twin_fixed_mul(ys, ys));
     return (twin_fixed_to_sfixed(twin_fixed_sqrt(ds)));
 }
+
+twin_fixed_t twin_matrix_transform_x(const twin_matrix_t *m,
+                                     twin_fixed_t x,
+                                     twin_fixed_t y)
+{
+    return twin_sfixed_to_fixed(_twin_matrix_x((twin_matrix_t *) m, x, y));
+}
+
+twin_fixed_t twin_matrix_transform_y(const twin_matrix_t *m,
+                                     twin_fixed_t x,
+                                     twin_fixed_t y)
+{
+    return twin_sfixed_to_fixed(_twin_matrix_y((twin_matrix_t *) m, x, y));
+}


### PR DESCRIPTION
This commit adds twin_custom_widget_t API:
- twin_custom_widget_create() for widget creation with user data
- Helper functions for width, height, pixmap access, and paint queuing
- twin_matrix_transform_x/y() for coordinate transformations
- Proper dispatch mechanism calling base widget handlers first

It refactors all demo applications to use public API only:
- Remove twin_private.h dependencies from 'apps'
- Convert clock, line, spline, animation, image demos
- Replace internal _twin_* calls with public equivalents

Close #9 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces a new public custom widget API, enhancing widget creation and management with user-defined data. It refactors demo applications to eliminate dependencies on private headers, improving modularity and maintainability across the codebase. Key updates include functions for widget dimensions, repaint requests, and coordinate transformations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are well-structured and clearly documented, making the review process straightforward.
-->
</div>