### PR TITLE
Fix NULL pointer dereferences after malloc

### DIFF
--- a/src/image-gif.c
+++ b/src/image-gif.c
@@ -554,7 +554,18 @@ static twin_animation_t *_twin_animation_from_gif_file(const char *path)
 
     anim->n_frames = frame_count;
     anim->frames = malloc(sizeof(twin_pixmap_t *) * frame_count);
+    if (!anim->frames) {
+        free(anim);
+        gif_close(gif);
+        return NULL;
+    }
     anim->frame_delays = malloc(sizeof(twin_time_t) * frame_count);
+    if (!anim->frame_delays) {
+        free(anim->frames);
+        free(anim);
+        gif_close(gif);
+        return NULL;
+    }
 
     gif_rewind(gif);
     uint8_t *color, *frame;

--- a/src/path.c
+++ b/src/path.c
@@ -581,6 +581,8 @@ twin_path_t *twin_path_create(void)
     twin_path_t *path;
 
     path = malloc(sizeof(twin_path_t));
+    if (!path)
+        return NULL;
     path->npoints = path->size_points = 0;
     path->nsublen = path->size_sublen = 0;
     path->points = 0;

--- a/src/poly.c
+++ b/src/poly.c
@@ -302,6 +302,8 @@ void twin_fill_path(twin_pixmap_t *pixmap,
 
     int nalloc = path->npoints + path->nsublen + 1;
     twin_edge_t *edges = malloc(sizeof(twin_edge_t) * nalloc);
+    if (!edges)
+        return;
     int p = 0;
     int nedges = 0;
     for (int s = 0; s <= path->nsublen; s++) {

--- a/src/window.c
+++ b/src/window.c
@@ -208,6 +208,8 @@ void twin_window_set_name(twin_window_t *window, const char *name)
     window->name = malloc(strlen(name) + 1);
     if (window->name)
         strcpy(window->name, name);
+    else
+        window->name = NULL; /* Ensure consistent state on allocation failure */
     twin_window_draw(window);
 }
 


### PR DESCRIPTION
This adds missing NULL checks after memory allocation in multiple core files to prevent crashes when malloc fails. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances application stability by adding NULL checks after memory allocations in core files, preventing potential crashes from dereferencing NULL pointers. These modifications ensure graceful handling of memory allocation failures.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on error handling, making the review process relatively simple.
-->
</div>