### PR TITLE
Fix memory leaks in widget/window lifecycle

### DIFF
--- a/src/box.c
+++ b/src/box.c
@@ -158,6 +158,17 @@ twin_dispatch_result_t _twin_box_dispatch(twin_widget_t *widget,
         _twin_widget_dispatch(widget, event) == TwinDispatchDone)
         return TwinDispatchDone;
     switch (event->kind) {
+    case TwinEventDestroy:
+        /* Destroy all children first */
+        while (box->children) {
+            child = box->children;
+            box->children = child->next;
+
+            /* Send destroy event to child */
+            ev.kind = TwinEventDestroy;
+            (*child->dispatch)(child, &ev);
+        }
+        break;
     case TwinEventQueryGeometry:
         return _twin_box_query_geometry(box);
     case TwinEventConfigure:

--- a/src/label.c
+++ b/src/label.c
@@ -73,6 +73,11 @@ twin_dispatch_result_t _twin_label_dispatch(twin_widget_t *widget,
     case TwinEventQueryGeometry:
         _twin_label_query_geometry(label);
         break;
+    case TwinEventDestroy:
+        /* Free the label text */
+        if (label->label)
+            free(label->label);
+        break;
     default:
         break;
     }

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -51,6 +51,7 @@ twin_pixmap_t *twin_pixmap_create(twin_format_t format,
 #if defined(CONFIG_DROP_SHADOW)
     pixmap->shadow = false;
 #endif
+    pixmap->window = NULL; /* Initialize window field */
     pixmap->p.v = pixmap + 1;
     memset(pixmap->p.v, '\0', space);
     return pixmap;
@@ -80,6 +81,7 @@ twin_pixmap_t *twin_pixmap_create_const(twin_format_t format,
     pixmap->origin_x = pixmap->origin_y = 0;
     pixmap->stride = stride;
     pixmap->disable = 0;
+    pixmap->window = NULL; /* Initialize window field */
     pixmap->p = pixels;
     return pixmap;
 }

--- a/src/widget.c
+++ b/src/widget.c
@@ -96,6 +96,9 @@ twin_dispatch_result_t _twin_widget_dispatch(twin_widget_t *widget,
         _twin_widget_paint(widget);
         widget->paint = false;
         break;
+    case TwinEventDestroy:
+        /* Base widget has no special cleanup */
+        break;
     default:
         break;
     }

--- a/src/window.c
+++ b/src/window.c
@@ -95,6 +95,11 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
 void twin_window_destroy(twin_window_t *window)
 {
     twin_window_hide(window);
+
+    /* Call the destroy callback if set to clean up window contents */
+    if (window->destroy)
+        (*window->destroy)(window);
+
     twin_pixmap_destroy(window->pixmap);
     free(window->name);
     free(window);


### PR DESCRIPTION
This adds proper destroy event handling throughout the widget hierarchy to fix memory leaks:
- box: Propagate destroy events to all child widgets before destruction
- widget: Add TwinEventDestroy case to base widget dispatch
- label: Free dynamically allocated label text on destroy
- window: Invoke destroy callbacks to allow proper resource cleanup
- pixmap: Initialize window field to prevent undefined behavior 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request addresses memory leaks by implementing proper destroy event handling in the widget and window lifecycle. Key changes include propagating destroy events to child widgets, freeing dynamically allocated resources, and initializing fields to prevent undefined behavior.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on resource management, making the review process relatively simple.
-->
</div>