### PR TITLE
Prevent crashes from invalid closures in work/timeout queues

### DIFF
--- a/src/twin_private.h
+++ b/src/twin_private.h
@@ -810,4 +810,38 @@ void twin_custom_widget_destroy(twin_custom_widget_t *custom);
 /* Path convex hull computation */
 twin_path_t *twin_path_convex_hull(twin_path_t *path);
 
+/*
+ * Memory pointer validation
+ *
+ * This defines the minimum valid pointer address for closure validation.
+ * Different environments have different memory layouts:
+ *
+ * - Unix-like systems (Linux/BSD/macOS/Solaris): First 4KB (0x1000) typically
+ * unmapped
+ * - Windows: First 64KB (0x10000) reserved
+ * - Bare-metal: May have valid memory starting at 0x0
+ */
+#ifndef TWIN_POINTER_MIN_VALID
+#if defined(_WIN32) || defined(_WIN64)
+#define TWIN_POINTER_MIN_VALID 0x10000 /* Windows: 64KB */
+#elif defined(__unix__) || defined(__unix) || defined(unix) ||             \
+    (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) ||     \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__) || defined(__sun) || defined(__HAIKU__) ||      \
+    defined(__ANDROID__)
+#define TWIN_POINTER_MIN_VALID 0x1000 /* Unix-like: 4KB */
+#else
+#define TWIN_POINTER_MIN_VALID 0x100 /* Bare-metal/embedded: 256 bytes */
+#endif
+#endif
+
+/*
+ * Validate a pointer for basic sanity
+ * Returns true if the pointer appears to be valid
+ */
+static inline bool twin_pointer_valid(const void *ptr)
+{
+    return ptr && (uintptr_t) ptr >= TWIN_POINTER_MIN_VALID;
+}
+
 #endif /* _TWIN_PRIVATE_H_ */


### PR DESCRIPTION
Platform-aware pointer validation is added to prevent invalid memory access when callbacks execute with freed widget pointers. It validates closures both at scheduling time and before execution.

Fixes crashes in _twin_toplevel_paint() during mouse event handling. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request implements critical bug fixes to prevent crashes from invalid closure pointers in work and timeout queues. It introduces platform-aware pointer validation, ensuring closures are validated at both scheduling and execution times, addressing memory access violations during mouse event handling.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and focused on bug fixes, making the review process relatively simple.
-->
</div>