### PR TITLE
Fix aml dependency version for neatvnc

### DIFF
--- a/tools/build-neatvnc.sh
+++ b/tools/build-neatvnc.sh
@@ -6,7 +6,10 @@ sudo apt install -y meson ninja-build libpixman-1-dev zlib1g-dev libdrm-dev pkg-
 
 TOP_DIR=$(pwd)
 # Clone and build aml
-git clone https://github.com/any1/aml && pushd aml
+if [ ! -d "aml" ]; then
+    git clone https://github.com/any1/aml --depth=1 -b v0.3.0
+fi
+pushd aml
 meson -Dprefix=$TOP_DIR/_static --default-library=static build
 ninja -C build install
 popd
@@ -14,7 +17,10 @@ popd
 export PKG_CONFIG_PATH=$TOP_DIR/_static/lib/$(uname -m)-linux-gnu/pkgconfig
 
 # Clone and build NeatVNC
-git clone https://github.com/any1/neatvnc --depth=1 -b v0.8.1 && pushd neatvnc
+if [ ! -d "neatvnc" ]; then
+    git clone https://github.com/any1/neatvnc --depth=1 -b v0.8.1
+fi
+pushd neatvnc
 meson -Dprefix=$TOP_DIR/_static --default-library=static build
 ninja -C build install
 popd


### PR DESCRIPTION
When building neatvnc v0.8.1, the following error occurs:

```
meson.build:71:7: ERROR: Dependency "aml" not found, tried pkgconfig and cmake
```

According to `meson.build:66`, neatvnc explicitly requires:

```
aml_version = ['>=0.3.0', '<0.4.0']
```

This PR updates the dependency to match the required aml version range (`0.3.x`).
It ensures the build succeeds and prevents version mismatch issues.

**Checklist:**

* [x] Verified that build succeeds with aml v0.3.0
* [x] Confirmed run demo program with the VNC backend