### PR TITLE
fix: improve Windows menuconfig style compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,15 @@ endif
 
 # Menuconfig
 .PHONY: config
+KCONFIGLIB_AVAILABLE := $(shell python3 -c "import kconfiglib" >/dev/null 2>&1 && echo 1 || echo 0)
+
 config: configs/Kconfig
+ifeq ($(KCONFIGLIB_AVAILABLE),1)
+	@echo ">>> Using Kconfiglib"
+	@python3 -m menuconfig $<
+	@python3 -m genconfig $<
+else
+	@echo ">>> Falling back to local tools"
 	@tools/kconfig/menuconfig.py $<
 	@tools/kconfig/genconfig.py $<
+endif

--- a/tools/kconfig/menuconfig.py
+++ b/tools/kconfig/menuconfig.py
@@ -285,7 +285,7 @@ view the help of the selected item without leaving the dialog.
 
 _STYLES = {
     "default": """
-    path=fg:white,bg:back,bold
+    path=fg:white,bg:black,bold
     separator=fg:white,bg:blue,bold
     list=fg:white,bg:black
     selection=fg:black,bg:white,bold


### PR DESCRIPTION
This patch fixes the menuconfig style issue on Windows:

1. `"back"` is not a valid color name in `_NAMED_COLORS`.
2. The Windows Python environment does not support `-1` as a color value.

To improve cross-platform compatibility, the background color has been explicitly set to `black`.

Before:
<img width="1044" height="194" alt="image" src="https://github.com/user-attachments/assets/49e951c9-75ba-4a65-a105-07f43c047d7c" />

After:
<img width="1138" height="605" alt="image" src="https://github.com/user-attachments/assets/e23fbf8c-5a45-41be-9d8f-ff1075f62339" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix Windows menuconfig styling by replacing the invalid background color “back” with “black” in the path style. This avoids Windows terminal color errors (-1 not supported) and ensures consistent, readable colors.

<!-- End of auto-generated description by cubic. -->

