### PR TITLE
Refine build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,3 @@
-# Ensure tools/kconfig submodule is initialized
-ifeq ($(wildcard tools/kconfig/menuconfig.py),)
-    $(shell git submodule update --init tools/kconfig)
-endif
-
 -include .config
 
 check_goal := $(strip $(MAKECMDGOALS))
@@ -189,7 +184,12 @@ endif
 
 KCONFIGLIB := tools/kconfig/kconfiglib.py
 $(KCONFIGLIB):
-	git submodule update --init tools/kconfig
+	@if [ -d .git ]; then \
+	    git submodule update --init tools/kconfig; \
+	else \
+	    echo "Error: Kconfig tools not found"; \
+	    exit 1; \
+	fi
 
 # Load default configuration
 .PHONY: defconfig

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -308,7 +308,7 @@ _cmd_compile.cxx.host     = $(HOSTCXX) $(__HOSTARCHFLAGS) $(__CXXFLAGS) $($1_arc
                             $$($1_$$<_cxxflags-y) $($1_includes) -c -o $$@ $$<
 _cmd_link.cxx.host        = $(HOSTCXX) $(__HOSTARCHFLAGS) $(__CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends_y),$$^) \
                             $($1_archflags) $($1_ldflags) $(__LDFLAGS)
-_cmd_link_so.cxx.host     = $(HOSTCXX) $(__HOSTARCHFLAGS) $(__CXXFLAGS)$($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends_y),$$^) \
+_cmd_link_so.cxx.host     = $(HOSTCXX) $(__HOSTARCHFLAGS) $(__CXXFLAGS) $($1_libraries) -o $$@ $$(filter-out __FORCE $($1_depends_y),$$^) \
                             $($1_archflags) $($1_ldflags) $$(filter-out -static,$(__LDFLAGS)) -shared $$(if $($1_soname-y),-Wl$$(comma)-soname$$(comma)$($1_soname-y),)
 
 _cmd_ar                   = $(AR) rcs $$@ $$(filter-out __FORCE $($1_depends_y),$$^)

--- a/mk/toolchain.mk
+++ b/mk/toolchain.mk
@@ -25,7 +25,7 @@ ifndef CXX
 CXX := $(CROSS_COMPILE)g++
 endif
 ifeq ("$(CC_IS_CLANG)", "1")
-override CXX := $(dir $(CC))$(subst clang,clang++,$(notdir $(CC)))
+override CXX := $(subst clang,clang++,$(CC))
 endif
 
 ifndef CPP
@@ -81,5 +81,5 @@ HOSTSTRIP := $(HOST_COMPILE)strip
 endif
 
 ifndef HOSTOBJCOPY
-HOSTOBJCOPY:= $(HOST_COMPILE)objcpy
+HOSTOBJCOPY := $(HOST_COMPILE)objcopy
 endif


### PR DESCRIPTION
- Remove duplicate git submodule initialization from Makefile header
- Consolidate submodule init logic into $(KCONFIGLIB) target with proper error handling
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refined the build system by moving Kconfig submodule init into the KCONFIGLIB target with clear error handling, and fixed small toolchain/linker issues to prevent build failures.

- **Refactors**
  - Consolidated Kconfig submodule init into $(KCONFIGLIB) with a .git check and explicit error on missing repo.

- **Bug Fixes**
  - Added missing space in _cmd_link_so.cxx.host to avoid merged flags.
  - Simplified clang++ resolution: derive CXX by substituting in CC.
  - Corrected HOSTOBJCOPY typo (objcpy -> objcopy).

<!-- End of auto-generated description by cubic. -->

