### PR TITLE
Fix build system issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,15 @@ endif
 
 CFLAGS += -include config.h
 
-# Only include build rules when not running configuration targets
-ifeq ($(filter $(check_goal),config defconfig),)
-include mk/common.mk
+# Only skip build rules when running ONLY config/defconfig (no other targets)
+ifneq ($(filter-out config defconfig,$(check_goal)),)
+    # Has targets other than config/defconfig
+    include mk/common.mk
+else ifeq ($(check_goal),)
+    # Empty goals means building 'all'
+    include mk/common.mk
 endif
+# Otherwise, only config/defconfig targets - skip mk/common.mk
 
 KCONFIGLIB := tools/kconfig/kconfiglib.py
 $(KCONFIGLIB):

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -4,18 +4,18 @@ config CONFIGURED
     bool
     default y
 
-# Dependency detection using Kbuild toolchain functions
+# Dependency detection using Kconfiglib shell function
 config HAVE_SDL2
-    def_bool $(success,pkg-config --exists sdl2)
+    def_bool $(shell,pkg-config --exists sdl2 && echo y)
 
 config HAVE_PIXMAN
-    def_bool $(success,pkg-config --exists pixman-1)
+    def_bool $(shell,pkg-config --exists pixman-1 && echo y)
 
 config HAVE_LIBPNG
-    def_bool $(success,pkg-config --exists libpng)
+    def_bool $(shell,pkg-config --exists libpng && echo y)
 
 config HAVE_LIBJPEG
-    def_bool $(success,pkg-config --exists libjpeg)
+    def_bool $(shell,pkg-config --exists libjpeg && echo y)
 
 choice
     prompt "Backend Selection"

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -681,10 +681,11 @@ __FORCE:
 # Only include dependencies when building known targets
 build-goals := all clean $(target-builds)
 ifneq ($(MAKECMDGOALS),)
-    # MAKECMDGOALS is not empty, check if it's a known target
-    ifneq ($(filter $(MAKECMDGOALS),$(build-goals)),)
-        # Known target, include dependencies (except for clean)
-        ifneq "$(MAKECMDGOALS)" "clean"
+    # MAKECMDGOALS is not empty, check if ALL goals are known
+    # (i.e., no unknown goals remain after filtering out known ones)
+    ifeq ($(filter-out $(build-goals),$(MAKECMDGOALS)),)
+        # All goals are known, include dependencies (except for clean-only builds)
+        ifeq ($(filter clean,$(MAKECMDGOALS)),)
             -include $(target-depends)
         endif
     endif


### PR DESCRIPTION
This addresses the following critical build system issues:
1. Kconfig syntax error
   - Replace unsupported `$(success,...)` with Kconfiglib's `$(shell,...)`
   - Use `def_bool $(shell,pkg-config --exists ... && echo y)` for dependency detection
2. Mixed target check logic
   - Change from "any goal matches" to "all goals match" logic
   - Use filter-out to verify all goals are known before including dependencies
   - Prevents build failures with mixed known/unknown targets
3. Multi-target invocation
   - Invert logic to only skip mk/common.mk for pure config/defconfig
   - Support mixed invocations like 'make defconfig all'
   - Handle empty goals (default to 'all')
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes critical build system issues by correcting Kconfig dependency detection and tightening target checks. Mixed invocations like "make defconfig all" now work, and builds won’t fail on unknown targets.

- **Bug Fixes**
  - Replaced unsupported Kconfig "$(success,...)" with "$(shell,...)" and added pkg-config checks for SDL2, Pixman, libpng, and libjpeg via def_bool.
  - Changed dependency inclusion to require all goals be known (using filter-out), and skip for clean-only builds.
  - Updated Makefile to include mk/common.mk unless running only config/defconfig; empty goals default to "all".

<!-- End of auto-generated description by cubic. -->

