### PR TITLE
Cache span buffer to eliminate per-frame malloc

### DIFF
--- a/include/twin.h
+++ b/include/twin.h
@@ -327,6 +327,10 @@ struct _twin_screen {
     /* Window manager */
     twin_coord_t button_x, button_y; /**< Window button position */
 
+    /* Span buffer cache for screen updates */
+    twin_argb32_t *span_cache;     /**< Cached span buffer */
+    twin_coord_t span_cache_width; /**< Cached span buffer width */
+
     /* Event processing: event filter callback */
     bool (*event_filter)(twin_screen_t *screen, twin_event_t *event);
 };


### PR DESCRIPTION
This implements span buffer cache in twin_screen_t to eliminate malloc and free on every screen update. Previous code allocated and freed the span buffer for each frame, creating unnecessary allocation overhead in the render loop.

Previous behavior:
- malloc() span buffer at start of twin_screen_update()
- free() span buffer at end of function
- Repeated every frame, creating allocation churn

New behavior:
- Allocate once, cache in screen->span_cache
- Reuse buffer if current width fits
- Realloc only when larger width needed
- Free cache only on screen destruction
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Caches the span buffer in twin_screen_t to remove per-frame malloc/free during screen updates, reducing allocation churn. Adds memory profiling to tools/perf to measure RSS and peak usage.

- **Refactors**
  - Add span_cache and span_cache_width to twin_screen_t; reuse the buffer across frames.
  - Realloc only when width grows; free the cache on screen destroy.

- **New Features**
  - Memory profiling mode in tools/perf with RSS delta and peak stats for common operations.
  - Fallback ARGB32 pixmap if assets/tux.png is missing.

<!-- End of auto-generated description by cubic. -->

