### PR TITLE
Add Cairo dependency detection for TOOL_FONTEDIT

### DIFF
--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -17,6 +17,9 @@ config HAVE_LIBPNG
 config HAVE_LIBJPEG
     def_bool $(shell,pkg-config --exists libjpeg && echo y || echo n)
 
+config HAVE_CAIRO
+    def_bool $(shell,pkg-config --exists cairo && echo y || echo n)
+
 choice
     prompt "Backend Selection"
     default BACKEND_SDL
@@ -281,9 +284,9 @@ config TOOLS
 config TOOL_FONTEDIT
     bool "Build scalable font editor"
     default y
-    depends on TOOLS && HAVE_SDL2
+    depends on TOOLS && HAVE_SDL2 && HAVE_CAIRO
     help
-      Interactive font editor for Twin font format.
+      Interactive font editor for Mado font format.
       Allows creation and modification of scalable fonts.
 
 config PERF_TEST


### PR DESCRIPTION
The font-edit tool requires Cairo library for rendering operations but the build configuration did not properly detect this dependency, causing build failures on systems without Cairo installed.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Cairo detection and require it for TOOL_FONTEDIT to prevent builds when Cairo isn’t installed. Also update help text to “Mado” font format.

- **Dependencies**
  - Add HAVE_CAIRO via pkg-config and make TOOL_FONTEDIT depend on HAVE_CAIRO (alongside HAVE_SDL2).

- **Bug Fixes**
  - Prevent build failures by skipping TOOL_FONTEDIT when Cairo is missing.

<!-- End of auto-generated description by cubic. -->

