### PR TITLE
Cache transform buffer to avoid per-frame malloc

### DIFF
--- a/include/twin.h
+++ b/include/twin.h
@@ -253,6 +253,10 @@ typedef struct _twin_pixmap {
 #endif
 
     twin_window_t *window; /**< Associated window (if any) */
+
+    /* Transform buffer cache for compositing operations */
+    void *xform_cache;       /**< Cached xform buffer */
+    size_t xform_cache_size; /**< Cached xform buffer size in bytes */
 } twin_pixmap_t;
 
 /**

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -52,6 +52,8 @@ twin_pixmap_t *twin_pixmap_create(twin_format_t format,
     pixmap->shadow = false;
 #endif
     pixmap->window = NULL; /* Initialize window field */
+    pixmap->xform_cache = NULL;
+    pixmap->xform_cache_size = 0;
     pixmap->p.v = pixmap + 1;
     memset(pixmap->p.v, '\0', space);
     return pixmap;
@@ -82,6 +84,8 @@ twin_pixmap_t *twin_pixmap_create_const(twin_format_t format,
     pixmap->stride = stride;
     pixmap->disable = 0;
     pixmap->window = NULL; /* Initialize window field */
+    pixmap->xform_cache = NULL;
+    pixmap->xform_cache_size = 0;
     pixmap->p = pixels;
     return pixmap;
 }
@@ -90,6 +94,7 @@ void twin_pixmap_destroy(twin_pixmap_t *pixmap)
 {
     if (pixmap->screen)
         twin_pixmap_hide(pixmap);
+    free(pixmap->xform_cache); /* Free xform buffer cache */
     free(pixmap);
 }
 


### PR DESCRIPTION
This implements transform buffer cache in twin_pixmap_t to eliminate malloc and free on every transform compositing operation. Previous code allocated and freed the xform buffer for each transformation, creating unnecessary allocation overhead in the render loop.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cached the transform buffer in twin_pixmap_t to stop per-frame malloc/free during compositing. This reduces allocation overhead in the render loop and should improve frame stability.

- **Refactors**
  - Added xform_cache and xform_cache_size to twin_pixmap_t.
  - Reuse or grow the cached buffer in twin_pixmap_init_xform; twin_pixmap_free_xform is now a no-op.
  - Initialize cache in pixmap_create and pixmap_create_const; free it in twin_pixmap_destroy.

<!-- End of auto-generated description by cubic. -->

