### PR TITLE
Prevent resource leak in SDL backend

### DIFF
--- a/backend/sdl.c
+++ b/backend/sdl.c
@@ -137,7 +137,7 @@ twin_context_t *twin_sdl_init(int width, int height)
                                SDL_WINDOW_SHOWN);
     if (!tx->win) {
         log_error("%s", SDL_GetError());
-        goto bail;
+        goto bail_sdl;
     }
 
     tx->pixels = malloc(width * height * sizeof(*tx->pixels));
@@ -192,6 +192,8 @@ bail_pixels:
     free(tx->pixels);
 bail_window:
     SDL_DestroyWindow(tx->win);
+bail_sdl:
+    SDL_Quit();
 bail:
     free(ctx->priv);
     free(ctx);


### PR DESCRIPTION
When twin_sdl_init() fails after successful SDL_Init() but before completion (e.g., SDL_CreateWindow fails), the SDL subsystem is not properly cleaned up, leaking system resources.

The bail chain was missing SDL_Quit() cleanup. Error paths jumped directly to 'bail' label which only freed memory, leaving SDL initialized.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Properly shuts down SDL when twin_sdl_init fails, preventing a resource leak after SDL_Init succeeds but window creation fails.

- **Bug Fixes**
  - Added SDL_Quit() to the error path via a new bail_sdl label.
  - Redirected SDL_CreateWindow failure to bail_sdl instead of bail.

<!-- End of auto-generated description by cubic. -->

