### PR TITLE
Unify widget callback mechanism with closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,7 @@ __pycache__/
 *.pyc
 
 # Configuration
-.config
-.config.old
+.config*
 config.h
 
 # CI pipeline

--- a/apps/animation.c
+++ b/apps/animation.c
@@ -56,8 +56,11 @@ static twin_time_t _apps_animation_timeout(twin_time_t now, void *closure)
 }
 
 static twin_dispatch_result_t _apps_animation_dispatch(twin_widget_t *widget,
-                                                       twin_event_t *event)
+                                                       twin_event_t *event,
+                                                       void *closure)
 {
+    (void) closure; /* unused parameter */
+
     twin_custom_widget_t *custom = twin_widget_get_custom(widget);
     if (!custom)
         return TwinDispatchContinue;

--- a/apps/calc.c
+++ b/apps/calc.c
@@ -129,18 +129,20 @@ static void _apps_calc_digit(apps_calc_t *calc, int digit)
     _apps_calc_update_value(calc);
 }
 
-static void _apps_calc_button_signal(twin_button_t *button,
-                                     twin_button_signal_t signal,
-                                     void *closure)
+static twin_dispatch_result_t _apps_calc_button_clicked(twin_widget_t *widget,
+                                                        twin_event_t *event,
+                                                        void *data)
 {
-    apps_calc_t *calc = closure;
+    if (event->kind != TwinEventButtonSignalUp)
+        return TwinDispatchContinue;
+
+    apps_calc_t *calc = data;
+    twin_button_t *button = (twin_button_t *) widget;
     int a, b;
 
-    if (signal != TwinButtonSignalDown)
-        return;
     int i = _apps_calc_button_to_id(calc, button);
     if (i < 0)
-        return;
+        return TwinDispatchContinue;
 
     switch (i) {
 #define _(x) APPS_CALC_##x
@@ -191,6 +193,7 @@ static void _apps_calc_button_signal(twin_button_t *button,
         _apps_calc_digit(calc, i);
         break;
     }
+    return TwinDispatchDone;
 }
 
 void apps_calc_start(twin_screen_t *screen,
@@ -220,8 +223,8 @@ void apps_calc_start(twin_screen_t *screen,
                 APPS_CALC_BUTTON_SIZE, APPS_CALC_BUTTON_STYLE);
             twin_widget_set(&calc->buttons[b]->label.widget,
                             APPS_CALC_BUTTON_BG);
-            calc->buttons[b]->signal = _apps_calc_button_signal;
-            calc->buttons[b]->closure = calc;
+            twin_widget_set_callback(&calc->buttons[b]->label.widget,
+                                     _apps_calc_button_clicked, calc);
             calc->buttons[b]->label.widget.shape = TwinShapeEllipse;
             if (i || j)
                 calc->buttons[b]->label.widget.copy_geom =

--- a/apps/clock.c
+++ b/apps/clock.c
@@ -204,8 +204,11 @@ static twin_time_t _apps_clock_timeout(twin_time_t now, void *closure)
 }
 
 static twin_dispatch_result_t _apps_clock_dispatch(twin_widget_t *widget,
-                                                   twin_event_t *event)
+                                                   twin_event_t *event,
+                                                   void *closure)
 {
+    (void) closure; /* unused parameter */
+
     twin_custom_widget_t *custom = twin_widget_get_custom(widget);
     if (!custom)
         return TwinDispatchContinue;

--- a/apps/line.c
+++ b/apps/line.c
@@ -71,8 +71,11 @@ static int _apps_line_hit(apps_line_data_t *line,
 }
 
 static twin_dispatch_result_t _apps_line_dispatch(twin_widget_t *widget,
-                                                  twin_event_t *event)
+                                                  twin_event_t *event,
+                                                  void *closure)
 {
+    (void) closure; /* unused parameter */
+
     twin_custom_widget_t *custom = twin_widget_get_custom(widget);
     if (!custom)
         return TwinDispatchContinue;

--- a/apps/spline.c
+++ b/apps/spline.c
@@ -113,20 +113,22 @@ static void _apps_spline_paint(twin_custom_widget_t *custom)
     twin_path_destroy(path);
 }
 
-static void _apps_spline_button_signal(twin_button_t *button,
-                                       twin_button_signal_t signal,
-                                       void *closure)
+static twin_dispatch_result_t _apps_spline_button_clicked(twin_widget_t *widget,
+                                                          twin_event_t *event,
+                                                          void *data)
 {
-    (void) button; /* unused parameter */
-    if (signal != TwinButtonSignalDown)
-        return;
+    (void) widget; /* unused parameter */
 
-    twin_custom_widget_t *custom = closure;
+    if (event->kind != TwinEventButtonSignalUp)
+        return TwinDispatchContinue;
+
+    twin_custom_widget_t *custom = data;
     apps_spline_data_t *spline =
         (apps_spline_data_t *) twin_custom_widget_data(custom);
     spline->n_points = (spline->n_points == 3) ? 4 : 3;
     _init_control_point(spline);
     twin_custom_widget_queue_paint(custom);
+    return TwinDispatchDone;
 }
 
 static twin_dispatch_result_t _apps_spline_update_pos(
@@ -167,8 +169,11 @@ static int _apps_spline_hit(apps_spline_data_t *spline,
 }
 
 static twin_dispatch_result_t _apps_spline_dispatch(twin_widget_t *widget,
-                                                    twin_event_t *event)
+                                                    twin_event_t *event,
+                                                    void *closure)
 {
+    (void) closure; /* unused parameter */
+
     twin_custom_widget_t *custom = twin_widget_get_custom(widget);
     if (!custom)
         return TwinDispatchContinue;
@@ -227,8 +232,8 @@ static twin_custom_widget_t *_apps_spline_init(twin_box_t *parent, int n_points)
         twin_button_create(parent, "Switch curve", 0xffae0000, D(10),
                            TwinStyleBold | TwinStyleOblique);
     twin_widget_set(&button->label.widget, 0xc0808080);
-    button->signal = _apps_spline_button_signal;
-    button->closure = custom;
+    twin_widget_set_callback(&button->label.widget, _apps_spline_button_clicked,
+                             custom);
     button->label.widget.shape = TwinShapeRectangle;
 
     return custom;

--- a/src/label.c
+++ b/src/label.c
@@ -60,11 +60,12 @@ static void _twin_label_paint(twin_label_t *label)
 }
 
 twin_dispatch_result_t _twin_label_dispatch(twin_widget_t *widget,
-                                            twin_event_t *event)
+                                            twin_event_t *event,
+                                            void *closure)
 {
     twin_label_t *label = (twin_label_t *) widget;
 
-    if (_twin_widget_dispatch(widget, event) == TwinDispatchDone)
+    if (_twin_widget_dispatch(widget, event, closure) == TwinDispatchDone)
         return TwinDispatchDone;
     switch (event->kind) {
     case TwinEventPaint:
@@ -112,10 +113,10 @@ void _twin_label_init(twin_label_t *label,
                       twin_argb32_t foreground,
                       twin_fixed_t font_size,
                       twin_style_t font_style,
-                      twin_dispatch_proc_t dispatch)
+                      twin_widget_proc_t handler)
 {
     static const twin_widget_layout_t preferred = {0, 0, 1, 1};
-    _twin_widget_init(&label->widget, parent, 0, preferred, dispatch);
+    _twin_widget_init(&label->widget, parent, 0, preferred, handler);
     label->label = NULL;
     label->offset.x = 0;
     label->offset.y = 0;

--- a/src/twin_private.h
+++ b/src/twin_private.h
@@ -544,16 +544,17 @@ void _twin_box_init(twin_box_t *box,
                     twin_box_t *parent,
                     twin_window_t *window,
                     twin_box_dir_t dir,
-                    twin_dispatch_proc_t dispatch);
+                    twin_widget_proc_t dispatch);
 
 twin_dispatch_result_t _twin_box_dispatch(twin_widget_t *widget,
-                                          twin_event_t *event);
+                                          twin_event_t *event,
+                                          void *closure);
 
 void _twin_widget_init(twin_widget_t *widget,
                        twin_box_t *parent,
                        twin_window_t *window,
                        twin_widget_layout_t preferred,
-                       twin_dispatch_proc_t dispatch);
+                       twin_widget_proc_t dispatch);
 
 void _twin_widget_paint_shape(twin_widget_t *widget,
                               twin_shape_t shape,
@@ -564,7 +565,9 @@ void _twin_widget_paint_shape(twin_widget_t *widget,
                               twin_fixed_t radius);
 
 twin_dispatch_result_t _twin_widget_dispatch(twin_widget_t *widget,
-                                             twin_event_t *event);
+                                             twin_event_t *event,
+                                             void *closure);
+
 
 void _twin_widget_queue_paint(twin_widget_t *widget);
 
@@ -584,16 +587,18 @@ void _twin_label_init(twin_label_t *label,
                       twin_argb32_t foreground,
                       twin_fixed_t font_size,
                       twin_style_t font_style,
-                      twin_dispatch_proc_t dispatch);
+                      twin_widget_proc_t dispatch);
 
 twin_dispatch_result_t _twin_label_dispatch(twin_widget_t *widget,
-                                            twin_event_t *event);
+                                            twin_event_t *event,
+                                            void *closure);
 
 twin_dispatch_result_t _twin_toplevel_dispatch(twin_widget_t *widget,
-                                               twin_event_t *event);
+                                               twin_event_t *event,
+                                               void *closure);
 
 void _twin_toplevel_init(twin_toplevel_t *toplevel,
-                         twin_dispatch_proc_t dispatch,
+                         twin_widget_proc_t dispatch,
                          twin_window_t *window,
                          const char *name);
 
@@ -602,7 +607,8 @@ void _twin_toplevel_queue_paint(twin_widget_t *widget);
 void _twin_toplevel_queue_layout(twin_widget_t *widget);
 
 twin_dispatch_result_t _twin_button_dispatch(twin_widget_t *widget,
-                                             twin_event_t *event);
+                                             twin_event_t *event,
+                                             void *closure);
 
 void _twin_button_init(twin_button_t *button,
                        twin_box_t *parent,
@@ -610,7 +616,7 @@ void _twin_button_init(twin_button_t *button,
                        twin_argb32_t foreground,
                        twin_fixed_t font_size,
                        twin_style_t font_style,
-                       twin_dispatch_proc_t dispatch);
+                       twin_widget_proc_t dispatch);
 
 typedef struct twin_backend {
     /* Initialize the backend */


### PR DESCRIPTION
Previous design had widget-specific callback mechanisms (button signals, scroll signals) with duplicated closure management code.

This commit introduces two complementary callback patterns:
1. Widget-level dispatch (for custom widgets and complex event handling)
   - Added `twin_widget_proc_t` with (widget, event, closure) signature
   - Unified closure storage in `twin_widget_t`
   - Used by custom widgets and applications needing full event access
2. Button-specific API (for simple click handling)
   - Added `twin_button_on_clicked(button, callback, data)`
   - Simplified signature: `void (*)(twin_button_t*, void*)`
   - Direct callback invocation on button click
   - Used by calc, image, spline demos

Button signals promoted to standard events (TwinEventButtonSignal*). Removed obsolete scroll signal typedefs and button-specific fields.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Unifies widget event handling with a closure-based API and adds a simple button click callback to replace widget-specific signal plumbing. This standardizes callbacks across widgets and simplifies demo apps.

- **New Features**
  - Added twin_widget_proc_t(widget, event, closure) and closure storage on twin_widget_t.
  - Added twin_widget_set_callback(widget, callback, data) for app-level event callbacks.
  - Added twin_button_on_clicked(button, callback, data) for straightforward click handling.
  - Standardized button signals as events: TwinEventButtonSignalDown/Up.

- **Migration**
  - Replace dispatch with handler everywhere; use twin_widget_create_with_handler(...) and update function signatures to include void *closure.
  - For custom widgets, pass a handler to twin_custom_widget_create(...).
  - Stop using button signal callbacks; use twin_button_on_clicked(...).
  - Removed scroll signal typedefs and button-specific signal fields.

<!-- End of auto-generated description by cubic. -->

