### PR TITLE
Modularize package detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 -include .config
+include mk/deps.mk
 
 # Set default goal explicitly
 .DEFAULT_GOAL := all
@@ -93,9 +94,9 @@ libtwin.a_files-y += src/screen-ops.c
 # Renderer implementations (draw-builtin.c includes all compositing operations)
 libtwin.a_files-$(CONFIG_RENDERER_BUILTIN) += src/draw-builtin.c
 libtwin.a_files-$(CONFIG_RENDERER_PIXMAN) += src/draw-pixman.c
-libtwin.a_cflags-$(CONFIG_RENDERER_PIXMAN) += $(shell pkg-config --cflags pixman-1)
+libtwin.a_cflags-$(CONFIG_RENDERER_PIXMAN) += $(call dep,cflags,pixman-1)
 ifeq ($(CONFIG_RENDERER_PIXMAN), y)
-TARGET_LIBS += $(shell pkg-config --libs pixman-1)
+TARGET_LIBS += $(call dep,libs,pixman-1)
 endif
 
 # Image loaders
@@ -103,8 +104,8 @@ endif
 ifeq ($(CONFIG_LOADER_JPEG), y)
 libtwin.a_files-y += src/image-jpeg.c
 ifneq ($(CC_IS_EMCC), 1)
-libtwin.a_cflags-y += $(shell pkg-config --cflags libjpeg)
-TARGET_LIBS += $(shell pkg-config --libs libjpeg)
+libtwin.a_cflags-y += $(call dep,cflags,libjpeg)
+TARGET_LIBS += $(call dep,libs,libjpeg)
 else
 # Emscripten libjpeg port - flags needed for both compile and link
 libtwin.a_cflags-y += -sUSE_LIBJPEG=1
@@ -115,8 +116,8 @@ endif
 ifeq ($(CONFIG_LOADER_PNG), y)
 libtwin.a_files-y += src/image-png.c
 ifneq ($(CC_IS_EMCC), 1)
-libtwin.a_cflags-y += $(shell pkg-config --cflags libpng)
-TARGET_LIBS += $(shell pkg-config --libs libpng)
+libtwin.a_cflags-y += $(call dep,cflags,libpng)
+TARGET_LIBS += $(call dep,libs,libpng)
 else
 # Emscripten libpng port (includes zlib) - flags needed for both compile and link
 libtwin.a_cflags-y += -sUSE_LIBPNG=1 -sUSE_ZLIB=1
@@ -155,8 +156,8 @@ BACKEND := none
 ifeq ($(CONFIG_BACKEND_SDL), y)
 BACKEND = sdl
 libtwin.a_files-y += backend/sdl.c
-libtwin.a_cflags-y += $(shell sdl2-config --cflags)
-TARGET_LIBS += $(shell sdl2-config --libs)
+libtwin.a_cflags-y += $(call dep,cflags,sdl2)
+TARGET_LIBS += $(call dep,libs,sdl2)
 endif
 
 ifeq ($(CONFIG_BACKEND_FBDEV), y)
@@ -170,8 +171,8 @@ ifeq ($(CONFIG_BACKEND_VNC), y)
 BACKEND = vnc
 libtwin.a_files-y += backend/vnc.c
 libtwin.a_files-y += src/cursor.c
-libtwin.a_cflags-y += $(shell pkg-config --cflags neatvnc aml pixman-1)
-TARGET_LIBS += $(shell pkg-config --libs neatvnc aml pixman-1)
+libtwin.a_cflags-y += $(call dep,cflags,neatvnc aml pixman-1)
+TARGET_LIBS += $(call dep,libs,neatvnc aml pixman-1)
 endif
 
 ifeq ($(CONFIG_BACKEND_HEADLESS), y)
@@ -251,11 +252,11 @@ font-edit_files-y = \
 	tools/font-edit/font-edit.c
 font-edit_includes-y := tools/font-edit
 font-edit_cflags-y := \
-	$(shell pkg-config --cflags cairo) \
-	$(shell sdl2-config --cflags)
+	$(call dep,cflags,cairo) \
+	$(call dep,cflags,sdl2)
 font-edit_ldflags-y := \
-	$(shell pkg-config --libs cairo) \
-	$(shell sdl2-config --libs) \
+	$(call dep,libs,cairo) \
+	$(call dep,libs,sdl2) \
 	-lm
 
 # Headless control tool

--- a/mk/deps.mk
+++ b/mk/deps.mk
@@ -1,0 +1,52 @@
+# Unified dependency checking and flag retrieval system
+#
+# Usage: $(call dep,flag-type,package-name[s])
+#   flag-type: cflags or libs
+#   package-name[s]: single package or space-separated list (e.g., "cairo", "neatvnc aml")
+#
+# Automatically detects the right tool:
+# 1. Try package-config tool first (e.g., sdl2-config) - single package only
+# 2. Fall back to pkg-config if available - supports multiple packages
+# 3. Return empty string if package(s) not found
+#
+# Verbose mode: Set V=1 to show dependency-checking errors
+#   make V=1         # Show all pkg-config/config-tool errors
+#   make             # Silent mode (default)
+
+# Conditional stderr redirection based on V= flag
+ifeq ($(V),1)
+_dep_stderr :=
+else
+_dep_stderr := 2>/dev/null
+endif
+
+# Internal: Try package-specific config tool (single package only)
+# Usage: $(call _dep-config,package-name,flag-type)
+define _dep-config
+$(shell command -v $(1)-config >/dev/null 2>&1 && $(1)-config --$(2) $(_dep_stderr))
+endef
+
+# Internal: Try pkg-config (supports multiple packages)
+# Usage: $(call _dep-pkg,package-names,flag-type)
+define _dep-pkg
+$(shell pkg-config --$(2) $(1) $(_dep_stderr))
+endef
+
+# Internal: Check if input contains multiple packages
+# Usage: $(call _dep-multi,package-names)
+define _dep-multi
+$(filter-out $(firstword $(1)),$(1))
+endef
+
+# Main entry point: Unified dependency checker
+# Usage: $(call dep,flag-type,package-name[s])
+# Example: $(call dep,cflags,cairo)
+#          $(call dep,libs,sdl2)
+#          $(call dep,cflags,neatvnc aml pixman-1)
+define dep
+$(if $(call _dep-multi,$(2)),\
+	$(call _dep-pkg,$(2),$(1)),\
+	$(if $(call _dep-config,$(2),$(1)),\
+		$(call _dep-config,$(2),$(1)),\
+		$(call _dep-pkg,$(2),$(1))))
+endef


### PR DESCRIPTION
With the introduction of refined Kconfiglib, we can validate the package dependency via customized scripts, making configurations more flexible and accurate.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Modularized build-time package detection with a new mk/deps.mk helper, replacing scattered pkg-config/sdl2-config calls. This unifies cflags/libs retrieval, supports multi-package inputs, and prepares for Kconfiglib-based dependency checks.

- **Refactors**
  - Added dep(flag-type, package[s]) in mk/deps.mk: try <pkg>-config, then pkg-config; supports multiple packages; returns empty if not found; quiet by default, use V=1 for verbose.
  - Updated Makefile to use dep for pixman-1, libjpeg, libpng, sdl2, cairo, and neatvnc/aml/pixman-1, reducing repeated shell calls and centralizing dependency handling.

<!-- End of auto-generated description by cubic. -->

