### PR TITLE
Use `$(python)` built-in in Kconfig

### DIFF
--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
 
     - name: Install dependencies
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ tags
 __pycache__/
 *.pyc
 
+# Kconfiglib (cloned on demand via 'make config')
+tools/kconfig/
+
 # Configuration
 .config*
 config.h

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/kconfig"]
-	path = tools/kconfig
-	url = https://github.com/sysprog21/Kconfiglib

--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,7 @@ CFLAGS += -include config.h
 
 # Ensure composite-decls.h exists before including build rules
 # (needed for dependency generation in mk/common.mk)
-ifeq ($(filter config defconfig clean,$(MAKECMDGOALS)),)
+ifeq ($(filter config defconfig clean distclean,$(MAKECMDGOALS)),)
     ifeq ($(wildcard src/composite-decls.h),)
         $(shell scripts/gen-composite-decls.py > src/composite-decls.h)
     endif
@@ -287,14 +287,11 @@ else ifeq ($(check_goal),)
 endif
 # Otherwise, only config/defconfig targets - skip mk/common.mk
 
+KCONFIGLIB_REPO := https://github.com/sysprog21/Kconfiglib
 KCONFIGLIB := tools/kconfig/kconfiglib.py
 $(KCONFIGLIB):
-	@if [ -d .git ]; then \
-	    git submodule update --init tools/kconfig; \
-	else \
-	    echo "Error: Kconfig tools not found"; \
-	    exit 1; \
-	fi
+	$(RM) -r tools/kconfig
+	git clone --depth=1 $(KCONFIGLIB_REPO) tools/kconfig
 
 # Load default configuration
 .PHONY: defconfig
@@ -307,6 +304,11 @@ defconfig: $(KCONFIGLIB)
 config: $(KCONFIGLIB) configs/Kconfig
 	@tools/kconfig/menuconfig.py configs/Kconfig
 	@tools/kconfig/genconfig.py configs/Kconfig
+
+# Remove Kconfiglib and build artifacts
+.PHONY: distclean
+distclean: clean
+	$(RM) -r tools/kconfig
 
 # WebAssembly post-build: Copy artifacts to assets/web/
 .PHONY: wasm-install

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -9,20 +9,20 @@ menu "Toolchain Configuration"
 # Compiler detection using scripts/detect-compiler.py
 config COMPILER_TYPE
     string
-    default "$(shell,scripts/detect-compiler.py 2>/dev/null || echo Unknown)"
+    default "$(shell,python3 scripts/detect-compiler.py 2>/dev/null || echo Unknown)"
 
 config CC_IS_EMCC
-    def_bool $(shell,scripts/detect-compiler.py --is Emscripten 2>/dev/null && echo y || echo n)
+    def_bool $(python,assert run(sys.executable, 'scripts/detect-compiler.py', '--is', 'Emscripten'))
 
 config CC_IS_CLANG
-    def_bool $(shell,scripts/detect-compiler.py --is Clang 2>/dev/null && echo y || echo n)
+    def_bool $(python,assert run(sys.executable, 'scripts/detect-compiler.py', '--is', 'Clang'))
 
 config CC_IS_GCC
-    def_bool $(shell,scripts/detect-compiler.py --is GCC 2>/dev/null && echo y || echo n)
+    def_bool $(python,assert run(sys.executable, 'scripts/detect-compiler.py', '--is', 'GCC'))
 
 # Cross-compilation support detection
 config CROSS_COMPILE_ENABLED
-    def_bool $(shell,test -n "$(CROSS_COMPILE)" && echo y || echo n)
+    def_bool $(python,assert os.environ.get('CROSS_COMPILE'))
 
 config CROSS_COMPILE_PREFIX
     string
@@ -41,32 +41,32 @@ comment "Build mode: Native"
 
 endmenu
 
-# Dependency detection using Kconfiglib shell function
+# Dependency detection using Kconfiglib $(python,...) preprocessor function
 # For Emscripten builds, libraries are provided via ports system (-sUSE_*)
 # and do not require host pkg-config detection
 
 config HAVE_SDL2
     bool
     default n if CC_IS_EMCC
-    default $(shell,pkg-config --exists sdl2 && echo y || echo n) if !CC_IS_EMCC
+    default $(python,assert run('pkg-config', '--exists', 'sdl2')) if !CC_IS_EMCC
 
 config HAVE_PIXMAN
     default n if CC_IS_EMCC
-    def_bool $(shell,pkg-config --exists pixman-1 && echo y || echo n) if !CC_IS_EMCC
+    def_bool $(python,assert run('pkg-config', '--exists', 'pixman-1')) if !CC_IS_EMCC
 
 config HAVE_LIBPNG
     bool
     default y if CC_IS_EMCC
-    default $(shell,pkg-config --exists libpng && echo y || echo n) if !CC_IS_EMCC
+    default $(python,assert run('pkg-config', '--exists', 'libpng')) if !CC_IS_EMCC
 
 config HAVE_LIBJPEG
     bool
     default y if CC_IS_EMCC
-    default $(shell,pkg-config --exists libjpeg && echo y || echo n) if !CC_IS_EMCC
+    default $(python,assert run('pkg-config', '--exists', 'libjpeg')) if !CC_IS_EMCC
 
 config HAVE_CAIRO
     default n if CC_IS_EMCC
-    def_bool $(shell,pkg-config --exists cairo && echo y || echo n) if !CC_IS_EMCC
+    def_bool $(python,assert run('pkg-config', '--exists', 'cairo')) if !CC_IS_EMCC
 
 choice
     prompt "Backend Selection"


### PR DESCRIPTION
This replaces 'tools/kconfig' git submodule with shallow on-demand clone triggered by 'make defconfig' or 'make config'. Add 'make distclean' to remove the cloned Kconfiglib along with build artifacts.

It converts all boolean `$(shell,...)` checks in configs/Kconfig to the portable `$(python,...)` preprocessor function, which evaluates Python code in-process without spawning a shell. This eliminates shell-specific idioms (2>/dev/null, && echo y || echo n, test -n) and the shell injection vector from environment variables.

COMPILER_TYPE retains `$(shell,...)` since $(python,...) only returns y/n and cannot produce string output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Kconfig to the built-in $(python) function for boolean checks and fetch Kconfiglib via an on-demand shallow clone. This removes shell-specific logic, improves portability, and reduces risk from env-based shell injection; adds distclean for cleanup.

- **Refactors**
  - Replace boolean $(shell,...) in configs/Kconfig with $(python,...) that runs Python in-process and returns y/n.
  - Keep COMPILER_TYPE on $(shell,...) since it requires string output.

- **Dependencies**
  - Remove tools/kconfig submodule; clone Kconfiglib on demand during make config/defconfig (depth=1). Add make distclean to delete the clone.
  - Update CI to stop checking out submodules and ignore tools/kconfig in .gitignore.

<sup>Written for commit 0a06e457184af7cdd55d250b44bc8f9e52f44cfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

