### PR TITLE
Harden integer arithmetic and lifecycle

### DIFF
--- a/src/box.c
+++ b/src/box.c
@@ -24,7 +24,7 @@ void _twin_box_init(twin_box_t *box,
 
 static twin_dispatch_result_t _twin_box_query_geometry(twin_box_t *box)
 {
-    twin_event_t ev;
+    twin_event_t ev = {0};
     twin_widget_layout_t preferred = {.width = 0, .height = 0};
 
     if (box->dir == TwinBoxHorz) {
@@ -69,8 +69,8 @@ static twin_dispatch_result_t _twin_box_configure(twin_box_t *box)
     twin_coord_t height = _twin_widget_height(box);
     twin_coord_t actual;
     twin_coord_t pref;
-    twin_coord_t delta;
-    twin_coord_t delta_remain;
+    int32_t delta;
+    int32_t delta_remain;
     twin_coord_t stretch = 0;
     twin_coord_t pos = 0;
     twin_widget_t *child;
@@ -88,9 +88,9 @@ static twin_dispatch_result_t _twin_box_configure(twin_box_t *box)
         stretch = 1;
     delta = delta_remain = actual - pref;
     for (child = box->children; child; child = child->next) {
-        twin_event_t ev;
+        twin_event_t ev = {0};
         twin_coord_t stretch_this;
-        twin_coord_t delta_this;
+        int32_t delta_this;
         twin_rect_t extents;
 
         if (!child->next)
@@ -100,7 +100,7 @@ static twin_dispatch_result_t _twin_box_configure(twin_box_t *box)
                 stretch_this = child->preferred.stretch_width;
             else
                 stretch_this = child->preferred.stretch_height;
-            delta_this = delta * stretch_this / stretch;
+            delta_this = (int32_t) delta * stretch_this / stretch;
         }
         if (delta_remain < 0) {
             if (delta_this < delta_remain)
@@ -123,10 +123,10 @@ static twin_dispatch_result_t _twin_box_configure(twin_box_t *box)
             extents.top = pos;
             pos = extents.bottom = pos + child_h + delta_this;
         }
-        if (extents.left != ev.u.configure.extents.left ||
-            extents.top != ev.u.configure.extents.top ||
-            extents.right != ev.u.configure.extents.right ||
-            extents.bottom != ev.u.configure.extents.bottom) {
+        if (extents.left != child->extents.left ||
+            extents.top != child->extents.top ||
+            extents.right != child->extents.right ||
+            extents.bottom != child->extents.bottom) {
             ev.kind = TwinEventConfigure;
             ev.u.configure.extents = extents;
             child->handler(child, &ev, child->callback_data);
@@ -152,7 +152,7 @@ twin_dispatch_result_t _twin_box_dispatch(twin_widget_t *widget,
                                           void *closure)
 {
     twin_box_t *box = (twin_box_t *) widget;
-    twin_event_t ev;
+    twin_event_t ev = {0};
     twin_widget_t *child;
 
     if (event->kind != TwinEventPaint &&

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -33,6 +33,9 @@ static bool twin_pixmap_alloc_size(twin_format_t format,
     if (stride > SIZE_MAX - 3)
         return false;
     stride = ALIGN_UP(stride, 4);
+    /* Stride must fit in twin_coord_t (int16_t) for the pixmap struct. */
+    if (stride > INT16_MAX)
+        return false;
     if ((size_t) height > (SIZE_MAX - sizeof(twin_pixmap_t)) / stride)
         return false;
 
@@ -44,13 +47,20 @@ twin_pixmap_t *twin_pixmap_create(twin_format_t format,
                                   twin_coord_t width,
                                   twin_coord_t height)
 {
-    twin_coord_t stride = twin_bytes_per_pixel(format) * width;
-    /* Align stride to 4 bytes for proper uint32_t access in Pixman. */
-    if (!IS_ALIGNED(stride, 4))
-        stride = ALIGN_UP(stride, 4);
+    size_t size;
+    if (!twin_pixmap_alloc_size(format, width, height, &size))
+        return NULL;
 
-    twin_area_t space = (twin_area_t) stride * height;
-    twin_area_t size = sizeof(twin_pixmap_t) + space;
+    /* Compute stride in size_t to avoid int16_t overflow. */
+    size_t stride_sz =
+        ALIGN_UP((size_t) twin_bytes_per_pixel(format) * (size_t) width, 4);
+    size_t space = stride_sz * (size_t) height;
+
+    /* Stride must fit in twin_coord_t for the pixmap struct field. */
+    if (stride_sz > INT16_MAX)
+        return NULL;
+    twin_coord_t stride = (twin_coord_t) stride_sz;
+
     twin_pixmap_t *pixmap = twin_malloc(size);
     if (!pixmap)
         return NULL;
@@ -90,10 +100,8 @@ twin_pixmap_t *twin_pixmap_create_budget(twin_format_t format,
         return NULL;
 
     size_t full_size;
-    if (!twin_pixmap_alloc_size(format, max_width, max_height, &full_size))
-        return NULL;
-
-    if (full_size <= memory_budget)
+    if (twin_pixmap_alloc_size(format, max_width, max_height, &full_size) &&
+        full_size <= memory_budget)
         return twin_pixmap_create(format, max_width, max_height);
 
     if (memory_budget <= sizeof(twin_pixmap_t))
@@ -246,8 +254,8 @@ twin_pointer_t twin_pixmap_pointer(twin_pixmap_t *pixmap,
 {
     twin_pointer_t p;
 
-    p.b = (pixmap->p.b + y * pixmap->stride +
-           x * twin_bytes_per_pixel(pixmap->format));
+    p.b = (pixmap->p.b + (int32_t) y * pixmap->stride +
+           (int32_t) x * twin_bytes_per_pixel(pixmap->format));
     return p;
 }
 

--- a/src/queue.c
+++ b/src/queue.c
@@ -73,7 +73,5 @@ void _twin_queue_review_order(twin_queue_t *first)
     for (q = first; q; q = o) {
         o = q->order;
         q->order = 0;
-        if (q->deleted)
-            twin_free(q);
     }
 }

--- a/src/timeout.c
+++ b/src/timeout.c
@@ -21,6 +21,8 @@ static twin_time_t twin_now(void)
 
 static twin_queue_t *head;
 static twin_time_t start;
+static twin_timeout_t *deferred_free;
+static unsigned running_depth;
 
 static twin_order_t _twin_timeout_order(twin_queue_t *a, twin_queue_t *b)
 {
@@ -41,29 +43,120 @@ static void _twin_queue_timeout(twin_timeout_t *timeout, twin_time_t time)
     _twin_queue_insert(&head, _twin_timeout_order, &timeout->queue);
 }
 
+static void _twin_defer_timeout_free(twin_timeout_t *timeout)
+{
+    timeout->queue.next = deferred_free ? &deferred_free->queue : NULL;
+    deferred_free = timeout;
+}
+
+static void _twin_flush_timeout_free(void)
+{
+    while (deferred_free) {
+        twin_timeout_t *timeout = deferred_free;
+
+        deferred_free = (twin_timeout_t *) deferred_free->queue.next;
+        twin_free(timeout);
+    }
+}
+
+static void _twin_release_timeout(twin_timeout_t *timeout)
+{
+    if (timeout->closure)
+        _twin_closure_unref(timeout->closure);
+    timeout->closure = NULL;
+
+    if (running_depth)
+        _twin_defer_timeout_free(timeout);
+    else
+        twin_free(timeout);
+}
+
+static void _twin_delete_timeout(twin_timeout_t *timeout)
+{
+    if (!timeout || timeout->queue.deleted)
+        return;
+
+    _twin_queue_delete(&head, &timeout->queue);
+    _twin_release_timeout(timeout);
+}
+
 void _twin_run_timeout(void)
 {
     twin_time_t now = twin_now();
     twin_timeout_t *timeout;
     twin_time_t delay;
+    twin_timeout_t *first = NULL;
 
-    twin_timeout_t *first = (twin_timeout_t *) _twin_queue_set_order(&head);
-    for (timeout = first; timeout && twin_time_compare(now, >=, timeout->time);
-         timeout = (twin_timeout_t *) timeout->queue.order) {
-        /* Validate closure pointer using closure lifetime tracking */
-        if (!_twin_closure_is_valid(timeout->closure)) {
-            /* Invalid or freed closure, skip this timeout */
-            continue;
+    if (running_depth++ == 0) {
+        first = (twin_timeout_t *) _twin_queue_set_order(&head);
+        for (timeout = first;
+             timeout && twin_time_compare(now, >=, timeout->time);
+             timeout = (twin_timeout_t *) timeout->queue.order) {
+            /* Validate closure pointer using closure lifetime tracking */
+            if (!_twin_closure_is_valid(timeout->closure))
+                continue;
+
+            delay = (*timeout->proc)(now, timeout->closure);
+            if (timeout->queue.deleted) {
+                continue;
+            } else if (delay >= 0) {
+                timeout->time = twin_now() + delay;
+                _twin_queue_reorder(&head, _twin_timeout_order,
+                                    &timeout->queue);
+            } else {
+                _twin_delete_timeout(timeout);
+            }
+        }
+    } else {
+        size_t count = 0;
+        twin_timeout_t **snapshot;
+
+        for (twin_queue_t *q = head; q; q = q->next) {
+            timeout = (twin_timeout_t *) q;
+            if (!twin_time_compare(now, >=, timeout->time))
+                break;
+            count++;
         }
 
-        delay = (*timeout->proc)(now, timeout->closure);
-        if (delay >= 0) {
-            timeout->time = twin_now() + delay;
-            _twin_queue_reorder(&head, _twin_timeout_order, &timeout->queue);
-        } else
-            _twin_queue_delete(&head, &timeout->queue);
+        snapshot = count ? twin_malloc(sizeof(*snapshot) * count) : NULL;
+        if (!count || snapshot) {
+            size_t i = 0;
+
+            for (twin_queue_t *q = head; q && i < count; q = q->next)
+                snapshot[i++] = (twin_timeout_t *) q;
+
+            for (i = 0; i < count; i++) {
+                timeout = snapshot[i];
+                if (timeout->queue.deleted)
+                    continue;
+                if (!_twin_closure_is_valid(timeout->closure))
+                    continue;
+                if (!twin_time_compare(now, >=, timeout->time))
+                    break;
+
+                delay = (*timeout->proc)(now, timeout->closure);
+                if (timeout->queue.deleted) {
+                    continue;
+                } else if (delay >= 0) {
+                    timeout->time = twin_now() + delay;
+                    _twin_queue_reorder(&head, _twin_timeout_order,
+                                        &timeout->queue);
+                } else {
+                    _twin_delete_timeout(timeout);
+                }
+            }
+
+            twin_free(snapshot);
+        }
     }
-    _twin_queue_review_order(&first->queue);
+
+    if (--running_depth == 0) {
+        if (first)
+            _twin_queue_review_order(&first->queue);
+        _twin_flush_timeout_free();
+    } else if (first) {
+        _twin_queue_review_order(&first->queue);
+    }
 }
 
 twin_timeout_t *twin_set_timeout(twin_timeout_proc_t timeout_proc,
@@ -99,13 +192,7 @@ void twin_clear_timeout(twin_timeout_t *timeout)
     if (!timeout)
         return;
 
-    _twin_queue_delete(&head, &timeout->queue);
-
-    /* Unref the closure */
-    if (timeout->closure)
-        _twin_closure_unref(timeout->closure);
-
-    twin_free(timeout);
+    _twin_delete_timeout(timeout);
 }
 
 twin_time_t _twin_timeout_delay(void)

--- a/src/window.c
+++ b/src/window.c
@@ -75,8 +75,10 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
 #else
     window->pixmap = twin_pixmap_create(format, width, height);
 #endif
-    if (!window->pixmap)
+    if (!window->pixmap) {
+        twin_free(window);
         return NULL;
+    }
     twin_pixmap_clip(window->pixmap, window->client.left, window->client.top,
                      window->client.right, window->client.bottom);
     twin_pixmap_origin_to_clip(window->pixmap);
@@ -127,17 +129,28 @@ void twin_window_configure(twin_window_t *window,
                            twin_coord_t height)
 {
     bool need_repaint = false;
+    bool need_layout = false;
+    twin_rect_t border;
+
+    twin_window_style_size(style, &border);
 
     twin_pixmap_disable_update(window->pixmap);
-    if (style != window->style) {
-        window->style = style;
-        need_repaint = true;
-    }
     if (width != window->pixmap->width || height != window->pixmap->height) {
         twin_pixmap_t *old = window->pixmap;
+        twin_coord_t pix_w = width, pix_h = height;
+#if defined(CONFIG_DROP_SHADOW)
+        pix_w += window->shadow_x;
+        pix_h += window->shadow_y;
+#endif
+        twin_pixmap_t *new_pixmap =
+            twin_pixmap_create(old->format, pix_w, pix_h);
+        if (!new_pixmap) {
+            twin_pixmap_enable_update(window->pixmap);
+            return;
+        }
         int i;
 
-        window->pixmap = twin_pixmap_create(old->format, width, height);
+        window->pixmap = new_pixmap;
         window->pixmap->window = window;
         twin_pixmap_move(window->pixmap, x, y);
         if (old->screen)
@@ -145,6 +158,20 @@ void twin_window_configure(twin_window_t *window,
         for (i = 0; i < old->disable; i++)
             twin_pixmap_disable_update(window->pixmap);
         twin_pixmap_destroy(old);
+        need_layout = true;
+        need_repaint = true;
+    }
+    if (style != window->style) {
+        need_layout = true;
+        window->style = style;
+        need_repaint = true;
+    }
+    if (need_layout) {
+        window->client.left = border.left;
+        window->client.top = border.top;
+        window->client.right = width - border.right;
+        window->client.bottom = height - border.bottom;
+
         twin_pixmap_reset_clip(window->pixmap);
         twin_pixmap_clip(window->pixmap, window->client.left,
                          window->client.top, window->client.right,
@@ -212,12 +239,14 @@ void twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
 
 void twin_window_set_name(twin_window_t *window, const char *name)
 {
+    if (!name)
+        return;
+    char *new_name = twin_malloc(strlen(name) + 1);
+    if (!new_name)
+        return;
+    strcpy(new_name, name);
     twin_free(window->name);
-    window->name = twin_malloc(strlen(name) + 1);
-    if (window->name)
-        strcpy(window->name, name);
-    else
-        window->name = NULL; /* Ensure consistent state on allocation failure */
+    window->name = new_name;
     twin_window_draw(window);
 }
 
@@ -308,7 +337,7 @@ static void twin_window_frame(twin_window_t *window)
     twin_pixmap_origin_to_clip(pixmap);
 
     twin_path_move(path, text_x - twin_fixed_floor(menu_x), text_y);
-    twin_path_utf8(path, window->name);
+    twin_path_utf8(path, name);
     twin_paint_path(pixmap, TWIN_FRAME_TEXT, path);
 
     twin_pixmap_reset_clip(pixmap);
@@ -564,7 +593,8 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
         else
             window->active = true;
         twin_window_frame(window);
-        if (window != window->screen->top->window) {
+        if (window->screen->top && window->screen->top->window &&
+            window != window->screen->top->window) {
             window->screen->top->window->active = false;
             twin_window_frame(window->screen->top->window);
         }

--- a/src/work.c
+++ b/src/work.c
@@ -9,6 +9,8 @@
 #include "twin_private.h"
 
 static twin_queue_t *head;
+static twin_work_t *deferred_free;
+static unsigned running_depth;
 
 static twin_order_t _twin_work_order(twin_queue_t *a, twin_queue_t *b)
 {
@@ -26,23 +28,98 @@ static void _twin_queue_work(twin_work_t *work)
     _twin_queue_insert(&head, _twin_work_order, &work->queue);
 }
 
+static void _twin_defer_work_free(twin_work_t *work)
+{
+    work->queue.next = deferred_free ? &deferred_free->queue : NULL;
+    deferred_free = work;
+}
+
+static void _twin_flush_work_free(void)
+{
+    while (deferred_free) {
+        twin_work_t *work = deferred_free;
+
+        deferred_free = (twin_work_t *) deferred_free->queue.next;
+        twin_free(work);
+    }
+}
+
+static void _twin_release_work(twin_work_t *work)
+{
+    if (work->closure)
+        _twin_closure_unref(work->closure);
+    work->closure = NULL;
+
+    if (running_depth)
+        _twin_defer_work_free(work);
+    else
+        twin_free(work);
+}
+
+static void _twin_delete_work(twin_work_t *work)
+{
+    if (!work || work->queue.deleted)
+        return;
+
+    _twin_queue_delete(&head, &work->queue);
+    _twin_release_work(work);
+}
+
 void _twin_run_work(void)
 {
     twin_work_t *work;
-    twin_work_t *first;
+    twin_work_t *first = NULL;
 
-    first = (twin_work_t *) _twin_queue_set_order(&head);
-    for (work = first; work; work = (twin_work_t *) work->queue.order) {
-        /* Validate closure pointer using closure lifetime tracking */
-        if (!_twin_closure_is_valid(work->closure)) {
-            /* Invalid or freed closure, skip this work item */
-            continue;
+    if (running_depth++ == 0) {
+        first = (twin_work_t *) _twin_queue_set_order(&head);
+        for (work = first; work; work = (twin_work_t *) work->queue.order) {
+            /* Validate closure pointer using closure lifetime tracking */
+            if (!_twin_closure_is_valid(work->closure))
+                continue;
+
+            if (!(*work->proc)(work->closure))
+                _twin_delete_work(work);
+            else if (!work->queue.deleted)
+                _twin_queue_reorder(&head, _twin_work_order, &work->queue);
         }
+    } else {
+        size_t count = 0;
+        twin_work_t **snapshot;
 
-        if (!(*work->proc)(work->closure))
-            _twin_queue_delete(&head, &work->queue);
+        for (twin_queue_t *q = head; q; q = q->next)
+            count++;
+
+        snapshot = count ? twin_malloc(sizeof(*snapshot) * count) : NULL;
+        if (!count || snapshot) {
+            size_t i = 0;
+
+            for (twin_queue_t *q = head; q; q = q->next)
+                snapshot[i++] = (twin_work_t *) q;
+
+            for (i = 0; i < count; i++) {
+                work = snapshot[i];
+                if (work->queue.deleted)
+                    continue;
+                if (!_twin_closure_is_valid(work->closure))
+                    continue;
+
+                if (!(*work->proc)(work->closure))
+                    _twin_delete_work(work);
+                else if (!work->queue.deleted)
+                    _twin_queue_reorder(&head, _twin_work_order, &work->queue);
+            }
+
+            twin_free(snapshot);
+        }
     }
-    _twin_queue_review_order(&first->queue);
+
+    if (--running_depth == 0) {
+        if (first)
+            _twin_queue_review_order(&first->queue);
+        _twin_flush_work_free();
+    } else if (first) {
+        _twin_queue_review_order(&first->queue);
+    }
 }
 
 twin_work_t *twin_set_work(twin_work_proc_t work_proc,
@@ -76,11 +153,5 @@ void twin_clear_work(twin_work_t *work)
     if (!work)
         return;
 
-    _twin_queue_delete(&head, &work->queue);
-
-    /* Unref the closure */
-    if (work->closure)
-        _twin_closure_unref(work->closure);
-
-    twin_free(work);
+    _twin_delete_work(work);
 }


### PR DESCRIPTION
pixmap: Compute stride in size_t to prevent int16_t overflow in twin_pixmap_create, validate stride fits in twin_coord_t, and widen pointer arithmetic in twin_pixmap_pointer to avoid overflow on embedded targets. Add stride bound check in twin_pixmap_alloc_size so twin_pixmap_create_budget cannot select invalid dimensions.

box: Widen delta/delta_remain/delta_this to int32_t since actual-pref can exceed int16_t range. Compare new extents against child->extents instead of uninitialized local, eliminating both undefined behavior and redundant configure event dispatch.

window: Free window on pixmap allocation failure in twin_window_create. Guard twin_window_configure against twin_pixmap_create returning NULL, keeping the old pixmap intact. Allocate new name before freeing old in twin_window_set_name to prevent data loss on allocation failure, and reject NULL name.

timeout/work: Introduce deferred-free lists with running_depth counter to prevent use-after-free when callbacks clear queue entries during iteration. Remove twin_free from _twin_queue_review_order since lifecycle ownership now belongs to the per-subsystem deferred flush. Add double-delete guards and re-entrant snapshot-based iteration for nested dispatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens integer arithmetic and queue lifecycle across pixmap, layout, timeout/work, and window code to prevent overflows, use-after-free, and null derefs. Improves stability on embedded targets and guards against allocation failures.

- **Bug Fixes**
  - Pixmap: compute stride in size_t, ensure it fits in `twin_coord_t`, and widen pointer math to avoid overflow; use `twin_pixmap_alloc_size` to validate total size and add a stride bound check so budgeted creation can’t pick invalid dimensions.
  - Box: use int32_t for layout deltas, cast scaled deltas to int32, compare against `child->extents`, and zero-initialize events to avoid undefined behavior and redundant configure events.
  - Window: free the window if pixmap allocation fails during create; on configure, allocate the new pixmap first (respecting drop shadow) and keep the old if allocation fails; recompute client rect from style; allocate the new name before freeing the old; reject NULL names; guard top-window access during focus changes.
  - Timeout/Work: add deferred-free lists and a `running_depth` counter to avoid use-after-free during iteration and nested dispatch; add closure validity checks, double-delete guards, and snapshot-based iteration; move frees out of `_twin_queue_review_order` to per-subsystem deferred flush.

<sup>Written for commit b72e766b6f7d53d022b719e27dcadff78b1cfb08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

