### PR TITLE
Fix broken Adler-32 in PNG encoder and harden CI

### DIFF
--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -94,8 +94,23 @@ jobs:
         ./headless-ctl shutdown
         wait $PID2 || true
 
+        # Verify PNGs are valid before comparing
+        for f in run1.png run2.png; do
+          if ! identify "$f" > /dev/null 2>&1; then
+            echo "ERROR: $f is not a valid PNG"
+            exit 1
+          fi
+        done
+
         # Compare images (allowing minor differences)
-        DIFF=$(compare -metric AE run1.png run2.png null: 2>&1 || echo "0")
+        # compare writes the metric to stderr, stdout gets the diff image
+        DIFF=$(compare -metric AE run1.png run2.png null: 2>&1) || true
+        # Extract just the numeric value (AE metric is an integer)
+        DIFF=$(echo "$DIFF" | grep -oE '^[0-9]+' | head -1)
+        if [ -z "$DIFF" ]; then
+          echo "ERROR: Failed to get pixel difference from compare"
+          exit 1
+        fi
         echo "Pixel difference: $DIFF"
 
         if [ "$DIFF" -gt "100" ]; then

--- a/tools/headless-ctl.c
+++ b/tools/headless-ctl.c
@@ -47,18 +47,6 @@ static double time_diff_ms(uint64_t start, uint64_t end)
 
 /* Writes PNG files without external dependencies */
 
-/* Portable byte swap for 32-bit values */
-#if defined(__GNUC__) || defined(__clang__)
-#define BSWAP32(x) __builtin_bswap32(x)
-#else
-static inline uint32_t bswap32(uint32_t x)
-{
-    return ((x & 0x000000ff) << 24) | ((x & 0x0000ff00) << 8) |
-           ((x & 0x00ff0000) >> 8) | ((x & 0xff000000) >> 24);
-}
-#define BSWAP32(x) bswap32(x)
-#endif
-
 /* CRC32 table for PNG chunk verification */
 static const uint32_t crc32_table[16] = {
     0x00000000, 0x1db71064, 0x3b6e20c8, 0x26d930ac, 0x76dc4190, 0x6b6b51f4,
@@ -98,10 +86,15 @@ static int save_png(const char *filename,
         return -1;
     size_t raw_sz = (size_t) height * row_size;
     /* Uncompressed DEFLATE: 2 (zlib hdr) + 5 per block + raw + 4 (adler).
-     * Ensure the total fits in a 32-bit PNG chunk length field.
+     * Guard every intermediate addition against size_t wrap before
+     * checking the total against the 32-bit PNG chunk length limit.
      */
+    if (raw_sz > SIZE_MAX - 65534)
+        return -1;
     size_t nblocks = (raw_sz + 65534) / 65535;
-    size_t idat_bound = 2 + nblocks * 5 + raw_sz + 4;
+    if (nblocks > (SIZE_MAX - 6 - raw_sz) / 5)
+        return -1;
+    size_t idat_bound = raw_sz + 6 + nblocks * 5;
     if (idat_bound > UINT32_MAX)
         return -1;
 
@@ -128,11 +121,16 @@ static int save_png(const char *filename,
 
 #define PUT_BYTES(buf, len) fwrite(buf, 1, len, fp)
 
-    /* Write IHDR chunk */
+    /* Write IHDR chunk (byte-level writes avoid unaligned access) */
     uint8_t ihdr[13];
-    uint32_t *p32 = (uint32_t *) ihdr;
-    p32[0] = BSWAP32(width);
-    p32[1] = BSWAP32(height);
+    ihdr[0] = (width >> 24) & 0xff;
+    ihdr[1] = (width >> 16) & 0xff;
+    ihdr[2] = (width >> 8) & 0xff;
+    ihdr[3] = width & 0xff;
+    ihdr[4] = (height >> 24) & 0xff;
+    ihdr[5] = (height >> 16) & 0xff;
+    ihdr[6] = (height >> 8) & 0xff;
+    ihdr[7] = height & 0xff;
     ihdr[8] = 8;  /* bit depth */
     ihdr[9] = 6;  /* color type: RGBA */
     ihdr[10] = 0; /* compression */

--- a/tools/headless-ctl.c
+++ b/tools/headless-ctl.c
@@ -84,6 +84,18 @@ static int save_png(const char *filename,
                     int width,
                     int height)
 {
+    if (width <= 0 || height <= 0)
+        return -1;
+
+    /* Guard against integer overflow in raw_size calculation.
+     * row_size = 1 + width*4, raw_size = height * row_size.
+     * Also ensure idat_size fits in a 32-bit PNG chunk length.
+     */
+    size_t row_size = 1 + (size_t) width * 4;
+    size_t raw_sz = (size_t) height * row_size;
+    if (raw_sz / row_size != (size_t) height || raw_sz > UINT32_MAX)
+        return -1;
+
     FILE *fp = fopen(filename, "wb");
     if (!fp)
         return -1;
@@ -125,10 +137,13 @@ static int save_png(const char *filename,
     crc = crc32(crc, ihdr, 13);
     PUT_U32(crc);
 
-    /* Write IDAT chunk */
-    size_t raw_size = height * (1 + width * 4); /* filter byte + RGBA per row */
-    size_t max_deflate_size =
-        raw_size + ((raw_size + 7) >> 3) + ((raw_size + 63) >> 6) + 11;
+    /* Write IDAT chunk (raw_sz validated above) */
+    size_t raw_size = raw_sz;
+    /* Uncompressed DEFLATE: 5-byte header per 65535-byte block + 2 zlib +
+     * 4 adler
+     */
+    size_t nblocks = (raw_size + 65534) / 65535;
+    size_t max_deflate_size = 2 + nblocks * 5 + raw_size + 4;
 
     uint8_t *idat = malloc(max_deflate_size);
     if (!idat) {
@@ -181,12 +196,15 @@ static int save_png(const char *filename,
         pos += chunk;
     }
 
-    /* ADLER32 checksum */
-    uint32_t adler = 1;
+    /* ADLER32 checksum: A = 1 + sum(bytes) mod 65521,
+     * B = sum(running A) mod 65521, result = (B << 16) | A
+     */
+    uint32_t adler_a = 1, adler_b = 0;
     for (size_t i = 0; i < raw_size; i++) {
-        adler = (adler + raw_data[i]) % 65521 +
-                ((((adler >> 16) + raw_data[i]) % 65521) << 16);
+        adler_a = (adler_a + raw_data[i]) % 65521;
+        adler_b = (adler_b + adler_a) % 65521;
     }
+    uint32_t adler = (adler_b << 16) | adler_a;
     idat[idat_size++] = (adler >> 24) & 0xff;
     idat[idat_size++] = (adler >> 16) & 0xff;
     idat[idat_size++] = (adler >> 8) & 0xff;

--- a/tools/headless-ctl.c
+++ b/tools/headless-ctl.c
@@ -87,13 +87,22 @@ static int save_png(const char *filename,
     if (width <= 0 || height <= 0)
         return -1;
 
-    /* Guard against integer overflow in raw_size calculation.
-     * row_size = 1 + width*4, raw_size = height * row_size.
-     * Also ensure idat_size fits in a 32-bit PNG chunk length.
+    /* Guard against integer overflow in size calculations.
+     * Check each multiplication step before it executes, so wrapped
+     * results never feed into downstream arithmetic.
      */
+    if ((size_t) width > (SIZE_MAX - 1) / 4)
+        return -1;
     size_t row_size = 1 + (size_t) width * 4;
+    if ((size_t) height > SIZE_MAX / row_size)
+        return -1;
     size_t raw_sz = (size_t) height * row_size;
-    if (raw_sz / row_size != (size_t) height || raw_sz > UINT32_MAX)
+    /* Uncompressed DEFLATE: 2 (zlib hdr) + 5 per block + raw + 4 (adler).
+     * Ensure the total fits in a 32-bit PNG chunk length field.
+     */
+    size_t nblocks = (raw_sz + 65534) / 65535;
+    size_t idat_bound = 2 + nblocks * 5 + raw_sz + 4;
+    if (idat_bound > UINT32_MAX)
         return -1;
 
     FILE *fp = fopen(filename, "wb");
@@ -137,13 +146,9 @@ static int save_png(const char *filename,
     crc = crc32(crc, ihdr, 13);
     PUT_U32(crc);
 
-    /* Write IDAT chunk (raw_sz validated above) */
+    /* Write IDAT chunk (sizes validated above) */
     size_t raw_size = raw_sz;
-    /* Uncompressed DEFLATE: 5-byte header per 65535-byte block + 2 zlib +
-     * 4 adler
-     */
-    size_t nblocks = (raw_size + 65534) / 65535;
-    size_t max_deflate_size = 2 + nblocks * 5 + raw_size + 4;
+    size_t max_deflate_size = idat_bound;
 
     uint8_t *idat = malloc(max_deflate_size);
     if (!idat) {


### PR DESCRIPTION
The hand-rolled PNG encoder in headless-ctl computed Adler-32 incorrectly: it used a single uint32_t accumulator instead of maintaining separate A/B components per RFC 1950. Every PNG produced had an invalid zlib checksum, causing ImageMagick to report "IDAT: incorrect data check" during CI comparison.

The CI test silently passed despite this because:
 - compare's error text was merged with the metric via 2>&1
 - the || echo "0" fallback turned the multi-line error into a string containing "0"
 - [ "$DIFF" -gt "100" ] on non-integer input failed, which was interpreted as "condition false", falling through to "Deterministic rendering test passed"

Fix the Adler-32 to use separate adler_a/adler_b accumulators with proper modular arithmetic. Add dimension validation to prevent integer overflow in buffer size calculations on 32-bit targets. Replace the heuristic max_deflate_size formula with an exact calculation. Harden the CI script with PNG validation via identify, line-anchored metric extraction, and explicit failure on unparseable output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Adler-32 checksum in the PNG encoder so generated images are valid, and makes CI image comparisons fail reliably instead of silently passing. Adds strict overflow and alignment guards to support 32-bit and strict-alignment targets.

- **Bug Fixes**
  - Correct Adler-32 computation using separate A/B accumulators per RFC 1950; write checksum as (B << 16) | A.
  - Validate width/height and guard every multiply/add to prevent size_t wrap; compute the exact uncompressed DEFLATE size (including zlib framing and block headers) and reject IDAT payloads > UINT32_MAX; write IHDR with byte-level big-endian fields to avoid unaligned access (drop BSWAP32).
  - CI: verify PNGs with `identify`, extract the AE metric with a line-anchored parse, and fail when the metric is missing or non-numeric.

<sup>Written for commit 6d4b46e53a8e8ac8e5d73ce996e9d7c261c1eba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

