### PR TITLE
Gate window management subsystem

### DIFF
--- a/apps/main.c
+++ b/apps/main.c
@@ -25,15 +25,15 @@
 
 #define ASSET_PATH "assets/"
 
-/*
- * Load the background pixmap from storage.
- * Return a default pattern if the load of @path or image loader fails.
- */
+#if defined(CONFIG_WINDOW_MANAGER)
 /*
  * Load the background pixmap from storage.
  * The screen compositor tiles backgrounds smaller than the screen,
  * so scaling is only needed when the source is larger.  When the
  * source fits, use it directly to avoid a full-screen allocation.
+ *
+ * In No-WM mode the single fullscreen window covers the entire screen,
+ * so the background is never visible and loading it wastes RAM.
  */
 static twin_pixmap_t *load_background(twin_screen_t *screen, const char *path)
 {
@@ -67,6 +67,7 @@ static twin_pixmap_t *load_background(twin_screen_t *screen, const char *path)
     twin_pixmap_destroy(raw_background);
     return scaled;
 }
+#endif /* CONFIG_WINDOW_MANAGER */
 
 static twin_context_t *tx = NULL;
 
@@ -89,6 +90,7 @@ static void sigint_handler(int sig)
 static void init_demo_apps(twin_context_t *ctx)
 {
     twin_screen_t *screen = ctx->screen;
+#if defined(CONFIG_WINDOW_MANAGER)
 #if defined(CONFIG_DEMO_MULTI)
     apps_multi_start(screen, "Demo", 100, 100, 400, 400);
 #endif
@@ -106,6 +108,24 @@ static void init_demo_apps(twin_context_t *ctx)
 #endif
 #if defined(CONFIG_DEMO_IMAGE)
     apps_image_start(screen, "Viewer", 20, 20);
+#endif
+#else
+    /*
+     * Without the window manager every window is pinned at (0,0), so launching
+     * multiple demos leaves later windows permanently covering earlier ones.
+     * Start a single demo in a deterministic order instead.
+     */
+#if defined(CONFIG_DEMO_CLOCK)
+    apps_clock_start(screen, "Clock", 10, 10, 200, 200);
+#elif defined(CONFIG_DEMO_CALCULATOR)
+    apps_calc_start(screen, "Calculator", 100, 100, 200, 200);
+#elif defined(CONFIG_DEMO_SPLINE)
+    apps_spline_start(screen, "Spline", 20, 20, 400, 400);
+#elif defined(CONFIG_DEMO_ANIMATION)
+    apps_animation_start(screen, "Viewer", ASSET_PATH "nyancat.gif", 20, 20);
+#elif defined(CONFIG_DEMO_IMAGE)
+    apps_image_start(screen, "Viewer", 20, 20);
+#endif
 #endif
     twin_screen_set_active(screen, screen->top);
 }
@@ -131,8 +151,10 @@ int main(void)
         twin_screen_set_cursor(tx->screen, cursor, hx, hy);
 #endif
 
+#if defined(CONFIG_WINDOW_MANAGER)
     twin_screen_set_background(
         tx->screen, load_background(tx->screen, ASSET_PATH "/tux.png"));
+#endif
 
     /* Start application with unified API (handles native and WebAssembly) */
     twin_run(tx, init_demo_apps);

--- a/configs/Kconfig
+++ b/configs/Kconfig
@@ -191,9 +191,27 @@ config CURSOR
       Enable custom cursor rendering and manipulation.
       Allows application control over cursor appearance.
 
+config WINDOW_MANAGER
+    bool "Enable window manager"
+    default y
+    help
+      Enable the window management subsystem: title bars,
+      decorations, drag-move, click-to-raise, iconify/restore,
+      and resize handles.
+
+      When disabled, windows are placed at (0,0) and clamped to
+      screen size. No decorations are drawn; the client area
+      covers the full pixmap. Pointer events route directly to
+      the window event handler without WM interpretation. The
+      demo launcher starts only the first enabled demo in this
+      mode to avoid inaccessible overlapping windows.
+
+      Disabling saves ~3-4 KB .text on ARM Cortex-M class targets.
+
 config DROP_SHADOW
     bool "Render drop shadow for active window"
     default y
+    depends on WINDOW_MANAGER
     help
       Add drop shadow effect to active window.
       Provides visual depth and window focus indication.
@@ -298,10 +316,12 @@ config DEMO_APPLICATIONS
 config DEMO_MULTI
     bool "Build multi demo"
     default y
-    depends on DEMO_APPLICATIONS
+    depends on DEMO_APPLICATIONS && WINDOW_MANAGER
     help
       Comprehensive demo with multiple windows and widgets.
       Demonstrates window management and event handling.
+      Requires window manager for staggered placement and
+      overlapping window interaction.
 
 config DEMO_CLOCK
     bool "Build clock demo"

--- a/include/twin.h
+++ b/include/twin.h
@@ -261,9 +261,7 @@ typedef struct _twin_pixmap {
     twin_animation_t *animation; /**< Animation data if animated */
     twin_pointer_t p;            /**< Pixel data pointer */
 
-#if defined(CONFIG_DROP_SHADOW)
     bool shadow; /**< Drop shadow for active windows */
-#endif
 
     twin_window_t *window; /**< Associated window (if any) */
 
@@ -527,9 +525,6 @@ extern twin_font_t twin_Default_Font_Roman;
 typedef enum _twin_window_style {
     TwinWindowPlain /**< Plain window without decorations */,
     TwinWindowApplication /**< Standard application window */,
-    TwinWindowFullScreen /**< Full screen window */,
-    TwinWindowDialog /**< Dialog window */,
-    TwinWindowAlert /**< Alert/popup window */
 } twin_window_style_t;
 
 typedef void (*twin_draw_func_t)(twin_window_t *window);
@@ -543,9 +538,7 @@ struct _twin_window {
     twin_screen_t *screen; /**< Parent screen */
     twin_pixmap_t *pixmap; /**< Window pixmap */
 
-#if defined(CONFIG_DROP_SHADOW)
     twin_coord_t shadow_x, shadow_y; /**< Shadow offset */
-#endif
 
     /* Window properties */
     twin_window_style_t style; /**< Window style */
@@ -556,7 +549,6 @@ struct _twin_window {
     bool active;      /**< Active window flag */
     bool iconify;     /**< Iconified state */
     bool client_grab; /**< Mouse grab state */
-    bool want_focus;  /**< Focus request flag */
     bool draw_queued; /**< Draw pending flag */
 
     /* Window data */
@@ -1526,11 +1518,11 @@ twin_pixmap_t *twin_custom_widget_pixmap(twin_custom_widget_t *custom);
  * Create window with decorations and event handling
  * @screen : Screen to display window on
  * @format : Pixel format for window contents
- * @style  : Window style (plain, application, fullscreen, etc.)
+ * @style  : Window style (plain or application)
  * @x      : Initial X position
  * @y      : Initial Y position
- * @width  : Window width including decorations
- * @height : Window height including decorations
+ * @width  : Client area width (decorations added internally)
+ * @height : Client area height (decorations added internally)
  *
  * Return Newly created window, or NULL on failure
  */
@@ -1561,13 +1553,6 @@ void twin_window_configure(twin_window_t *window,
                            twin_coord_t width,
                            twin_coord_t height);
 
-/* Check if the coordinates are within the window's range. */
-bool twin_window_valid_range(twin_window_t *window,
-                             twin_coord_t x,
-                             twin_coord_t y);
-
-void twin_window_style_size(twin_window_style_t style, twin_rect_t *size);
-
 void twin_window_set_name(twin_window_t *window, const char *name);
 
 void twin_window_draw(twin_window_t *window);
@@ -1579,8 +1564,6 @@ void twin_window_damage(twin_window_t *window,
                         twin_coord_t bottom);
 
 void twin_window_queue_paint(twin_window_t *window);
-
-bool twin_window_dispatch(twin_window_t *window, twin_event_t *event);
 
 #define TWIN_WORK_REDISPLAY 0
 #define TWIN_WORK_PAINT 1

--- a/src/draw-common.c
+++ b/src/draw-common.c
@@ -8,8 +8,6 @@
 #include "shadow-gaussian-lut.h"
 #include "twin_private.h"
 
-#define TWIN_TITLE_HEIGHT 20
-
 static void _twin_apply_stack_blur(twin_pixmap_t *trg_px,
                                    twin_pixmap_t *src_px,
                                    int radius,
@@ -153,6 +151,9 @@ void twin_stack_blur(twin_pixmap_t *px,
 }
 
 #if defined(CONFIG_DROP_SHADOW)
+
+#define TWIN_TITLE_HEIGHT 20
+
 /* Reuse bottom-strip weights between frames when width is unchanged. */
 static twin_a8_t *shadow_bottom_cache_weights;
 static twin_coord_t shadow_bottom_cache_capacity;

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -9,8 +9,10 @@
 
 #include "twin_private.h"
 
+#if defined(CONFIG_WINDOW_MANAGER)
 #define TWIN_BW 0
 #define TWIN_TITLE_HEIGHT 20
+#endif
 
 #define IS_ALIGNED(p, alignment) ((p % alignment) == 0)
 #define ALIGN_UP(sz, alignment)                            \
@@ -80,9 +82,7 @@ twin_pixmap_t *twin_pixmap_create(twin_format_t format,
     pixmap->stride = stride;
     pixmap->disable = 0;
     pixmap->animation = NULL;
-#if defined(CONFIG_DROP_SHADOW)
     pixmap->shadow = false;
-#endif
     pixmap->window = NULL; /* Initialize window field */
     pixmap->xform_cache = NULL;
     pixmap->xform_cache_size = 0;
@@ -418,6 +418,7 @@ bool twin_pixmap_transparent(twin_pixmap_t *pixmap,
 
 bool twin_pixmap_is_iconified(twin_pixmap_t *pixmap, twin_coord_t y)
 {
+#if defined(CONFIG_WINDOW_MANAGER)
     /*
      * Check whether the specified area within the pixmap corresponds to an
      * iconified window.
@@ -426,6 +427,10 @@ bool twin_pixmap_is_iconified(twin_pixmap_t *pixmap, twin_coord_t y)
         (pixmap->window->iconify &&
          y >= pixmap->y + TWIN_BW + TWIN_TITLE_HEIGHT + TWIN_BW))
         return true;
+#else
+    (void) y;
+    (void) pixmap;
+#endif
     return false;
 }
 
@@ -440,6 +445,6 @@ void twin_pixmap_move(twin_pixmap_t *pixmap, twin_coord_t x, twin_coord_t y)
 bool twin_pixmap_dispatch(twin_pixmap_t *pixmap, twin_event_t *event)
 {
     if (pixmap->window)
-        return twin_window_dispatch(pixmap->window, event);
+        return _twin_window_dispatch(pixmap->window, event);
     return false;
 }

--- a/src/screen.c
+++ b/src/screen.c
@@ -381,9 +381,9 @@ bool twin_screen_dispatch(twin_screen_t *screen, twin_event_t *event)
 
         /* check who the mouse is over now */
         for (ntarget = screen->top; ntarget; ntarget = ntarget->down)
-            if (twin_window_valid_range(ntarget->window,
-                                        event->u.pointer.screen_x,
-                                        event->u.pointer.screen_y))
+            if (_twin_window_valid_range(ntarget->window,
+                                         event->u.pointer.screen_x,
+                                         event->u.pointer.screen_y))
                 break;
 
         /* ah, somebody new ... send leave/enter events and set new target */

--- a/src/twin_private.h
+++ b/src/twin_private.h
@@ -859,6 +859,13 @@ void twin_composite_stroke(twin_pixmap_t *dst,
                            twin_operator_t operator,
                            twin_scratch_t * scratch);
 
+/* Internal window management helpers */
+void _twin_window_style_size(twin_window_style_t style, twin_rect_t *size);
+bool _twin_window_valid_range(twin_window_t *window,
+                              twin_coord_t x,
+                              twin_coord_t y);
+bool _twin_window_dispatch(twin_window_t *window, twin_event_t *event);
+
 /* Internal event handling */
 void twin_event_enqueue(const twin_event_t *event);
 

--- a/src/window.c
+++ b/src/window.c
@@ -9,6 +9,8 @@
 
 #include "twin_private.h"
 
+#if defined(CONFIG_WINDOW_MANAGER)
+
 #define TWIN_ACTIVE_BG 0xd03b80ae
 #define TWIN_INACTIVE_BG 0xffb0b0b0
 #define TWIN_FRAME_TEXT 0xffffffff
@@ -21,6 +23,8 @@
 
 /* Shadow color for CSS-style effect: semi-transparent black (50% opacity). */
 #define SHADOW_COLOR 0x80000000
+
+#endif /* CONFIG_WINDOW_MANAGER */
 
 twin_window_t *twin_window_create(twin_screen_t *screen,
                                   twin_format_t format,
@@ -39,6 +43,8 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
     window->style = style;
     window->active = false;
     window->iconify = false;
+
+#if defined(CONFIG_WINDOW_MANAGER)
     switch (window->style) {
     case TwinWindowApplication:
         left = TWIN_BW;
@@ -56,6 +62,20 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
     }
     width += left + right;
     height += top + bottom;
+#else
+    /* No-WM: ignore position, clamp to screen, no decorations */
+    left = 0;
+    top = 0;
+    right = 0;
+    bottom = 0;
+    x = 0;
+    y = 0;
+    if (width > screen->width)
+        width = screen->width;
+    if (height > screen->height)
+        height = screen->height;
+#endif
+
     window->client.left = left;
     window->client.top = top;
     window->client.right = width - right;
@@ -73,6 +93,8 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
     window->pixmap = twin_pixmap_create(format, width + window->shadow_x,
                                         height + window->shadow_y);
 #else
+    window->shadow_x = 0;
+    window->shadow_y = 0;
     window->pixmap = twin_pixmap_create(format, width, height);
 #endif
     if (!window->pixmap) {
@@ -86,7 +108,6 @@ twin_window_t *twin_window_create(twin_screen_t *screen,
     twin_pixmap_move(window->pixmap, x, y);
     window->damage = window->client;
     window->client_grab = false;
-    window->want_focus = false;
     window->draw_queued = false;
     window->client_data = 0;
     window->name = 0;
@@ -132,16 +153,24 @@ void twin_window_configure(twin_window_t *window,
     bool need_layout = false;
     twin_rect_t border;
 
-    twin_window_style_size(style, &border);
+#if defined(CONFIG_WINDOW_MANAGER)
+    _twin_window_style_size(style, &border);
+#else
+    /* No-WM: ignore position, clamp to screen, zero margins */
+    border.left = border.right = border.top = border.bottom = 0;
+    x = 0;
+    y = 0;
+    if (width > window->screen->width)
+        width = window->screen->width;
+    if (height > window->screen->height)
+        height = window->screen->height;
+#endif
 
     twin_pixmap_disable_update(window->pixmap);
     if (width != window->pixmap->width || height != window->pixmap->height) {
         twin_pixmap_t *old = window->pixmap;
-        twin_coord_t pix_w = width, pix_h = height;
-#if defined(CONFIG_DROP_SHADOW)
-        pix_w += window->shadow_x;
-        pix_h += window->shadow_y;
-#endif
+        twin_coord_t pix_w = width + window->shadow_x;
+        twin_coord_t pix_h = height + window->shadow_y;
         twin_pixmap_t *new_pixmap =
             twin_pixmap_create(old->format, pix_w, pix_h);
         if (!new_pixmap) {
@@ -185,19 +214,14 @@ void twin_window_configure(twin_window_t *window,
     twin_pixmap_enable_update(window->pixmap);
 }
 
-bool twin_window_valid_range(twin_window_t *window,
-                             twin_coord_t x,
-                             twin_coord_t y)
+#if defined(CONFIG_WINDOW_MANAGER)
+
+bool _twin_window_valid_range(twin_window_t *window,
+                              twin_coord_t x,
+                              twin_coord_t y)
 {
-    twin_coord_t offset_x = 0, offset_y = 0;
-#if defined(CONFIG_DROP_SHADOW)
-    /* Handle drop shadow. */
-    /*
-     * When the click coordinates fall within the drop shadow area, it will not
-     * be in the valid range of the window.
-     */
-    offset_x = window->shadow_x, offset_y = window->shadow_y;
-#endif
+    twin_coord_t offset_x = window->shadow_x;
+    twin_coord_t offset_y = window->shadow_y;
 
     switch (window->style) {
     case TwinWindowPlain:
@@ -221,7 +245,7 @@ bool twin_window_valid_range(twin_window_t *window,
     }
 }
 
-void twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
+void _twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
 {
     switch (style) {
     case TwinWindowPlain:
@@ -237,6 +261,27 @@ void twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
     }
 }
 
+#else /* !CONFIG_WINDOW_MANAGER */
+
+bool _twin_window_valid_range(twin_window_t *window,
+                              twin_coord_t x,
+                              twin_coord_t y)
+{
+    /* Simple bounds check without frame or shadow logic */
+    return window->pixmap->x <= x &&
+           x < window->pixmap->x + window->pixmap->width &&
+           window->pixmap->y <= y &&
+           y < window->pixmap->y + window->pixmap->height;
+}
+
+void _twin_window_style_size(twin_window_style_t style, twin_rect_t *size)
+{
+    (void) style;
+    size->left = size->right = size->top = size->bottom = 0;
+}
+
+#endif /* CONFIG_WINDOW_MANAGER */
+
 void twin_window_set_name(twin_window_t *window, const char *name)
 {
     if (!name)
@@ -249,6 +294,8 @@ void twin_window_set_name(twin_window_t *window, const char *name)
     window->name = new_name;
     twin_window_draw(window);
 }
+
+#if defined(CONFIG_WINDOW_MANAGER)
 
 static void twin_window_frame(twin_window_t *window)
 {
@@ -438,12 +485,15 @@ static void twin_window_drop_shadow(twin_window_t *window)
                     shadow_left + active_pix->window->shadow_x, shadow_top,
                     shadow_top + active_pix->window->shadow_y);
 }
-#endif
+#endif /* CONFIG_DROP_SHADOW */
+
+#endif /* CONFIG_WINDOW_MANAGER */
 
 void twin_window_draw(twin_window_t *window)
 {
     twin_pixmap_t *pixmap = window->pixmap;
 
+#if defined(CONFIG_WINDOW_MANAGER)
     switch (window->style) {
     case TwinWindowPlain:
     default:
@@ -452,6 +502,7 @@ void twin_window_draw(twin_window_t *window)
         twin_window_frame(window);
         break;
     }
+#endif
 
     /* if no draw function or no damage, return */
     if (window->draw == NULL || (window->damage.left >= window->damage.right ||
@@ -531,7 +582,9 @@ void twin_window_queue_paint(twin_window_t *window)
     }
 }
 
-bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
+#if defined(CONFIG_WINDOW_MANAGER)
+
+bool _twin_window_dispatch(twin_window_t *window, twin_event_t *event)
 {
     twin_event_t ev = *event;
     bool delegate = true;
@@ -548,6 +601,8 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
     twin_fixed_t title_right;
     twin_path_t *path = twin_path_create();
     const char *name = window->name;
+    if (!name)
+        name = "twin";
 
     text_width = twin_width_utf8(path, name);
     twin_path_destroy(path);
@@ -563,6 +618,26 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
     int local_x, local_y;
 
     switch (ev.kind) {
+    case TwinEventActivate:
+        /*
+         * Pure focus transition -- no pointer data in the event union.
+         * Update frame visuals but do not touch pointer coordinates.
+         */
+        if (window->iconify)
+            window->active = false;
+        else
+            window->active = true;
+        twin_window_frame(window);
+        if (window->screen->top && window->screen->top->window &&
+            window != window->screen->top->window) {
+            window->screen->top->window->active = false;
+            twin_window_frame(window->screen->top->window);
+        }
+#if defined(CONFIG_DROP_SHADOW)
+        twin_window_drop_shadow(window);
+#endif
+        delegate = false;
+        break;
     case TwinEventButtonDown:
         local_y = ev.u.pointer.screen_y - window->pixmap->y;
         if (local_y >= 0 && local_y <= TWIN_BW + TWIN_TITLE_HEIGHT + TWIN_BW) {
@@ -579,15 +654,7 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
                                    window->pixmap->height);
             }
         }
-    case TwinEventActivate:
-        /* Set window active. */
-        /*
-         * A iconified window is inactive. When the box is triggered by
-         * TwinEventButtonDown and the window is not iconified, it becomes
-         * active. For a window to be considered active, it must be the topmost
-         * window on the screen. The window's title bar turns blue to indicate
-         * the active state.
-         */
+        /* Activate the window on click */
         if (window->iconify)
             window->active = false;
         else
@@ -599,7 +666,6 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
             twin_window_frame(window->screen->top->window);
         }
 #if defined(CONFIG_DROP_SHADOW)
-        /* Handle drop shadow. */
         twin_window_drop_shadow(window);
 #endif
         if (window->client.left <= ev.u.pointer.x &&
@@ -671,3 +737,33 @@ bool twin_window_dispatch(twin_window_t *window, twin_event_t *event)
     }
     return false;
 }
+
+#else /* !CONFIG_WINDOW_MANAGER */
+
+bool _twin_window_dispatch(twin_window_t *window, twin_event_t *event)
+{
+    twin_event_t ev = *event;
+
+    /*
+     * No-WM dispatch: adjust pointer coordinates by client offset (both
+     * zero in No-WM mode, so effectively a no-op) and delegate directly
+     * to window->event. No drag, no iconify, no click-to-raise.
+     */
+    switch (ev.kind) {
+    case TwinEventButtonDown:
+    case TwinEventButtonUp:
+    case TwinEventMotion:
+        ev.u.pointer.x -= window->client.left;
+        ev.u.pointer.y -= window->client.top;
+        break;
+    default:
+        break;
+    }
+
+    if (window->event)
+        return (*window->event)(window, &ev);
+
+    return false;
+}
+
+#endif /* CONFIG_WINDOW_MANAGER */


### PR DESCRIPTION
This introduces Kconfig option (default y) that compiles out the entire window management layer: title bars, decorations, drag-move, iconify, click-to-raise, and resize handles. When disabled, windows are placed at (0,0), clamped to screen dimensions, with zero decoration margins and direct event dispatch to the application handler.

Kconfig wiring:
- CONFIG_DROP_SHADOW now depends on CONFIG_WINDOW_MANAGER
- CONFIG_DEMO_MULTI now depends on CONFIG_WINDOW_MANAGER

ABI cleanup batched into this change:
- Remove dead enum values (TwinWindowFullScreen/Dialog/Alert) that had zero callers and fell through to the default case
- Remove dead want_focus field from twin_window_t (never read)
- Unconditionally include shadow/shadow_x/shadow_y struct fields to eliminate the ABI hazard where different build configs produced different struct layouts
- Move internal-only helpers (twin_window_style_size, twin_window_valid_range, twin_window_dispatch) from the public API to twin_private.h with _twin_ prefix
- Fix twin_window_create doc: width/height are client area dimensions

No-WM mode in apps/main.c:
- Background loading compiled out
- Only a single demo launches to avoid inaccessible overlapping windows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a build-time switch to optionally compile out the window manager. Provides a No-WM mode with simpler window behavior and cleans up the public API/ABI.

- **New Features**
  - Added `WINDOW_MANAGER` Kconfig (default y) to enable/disable the WM: title bars, decorations, drag-move, click-to-raise, iconify/restore, resize.
  - No-WM mode: windows are pinned at (0,0), clamped to screen, no decorations, and pointer events go straight to the app handler.
  - No-WM apps: background loading is skipped and only the first enabled demo launches to avoid overlap.
  - Kconfig: `DROP_SHADOW` and `DEMO_MULTI` now depend on `WINDOW_MANAGER`. Saves ~3–4 KB .text on Cortex-M targets.

- **Refactors**
  - Removed unused styles from `twin_window_style_t` and the dead `want_focus` field.
  - Made `shadow`, `shadow_x`, and `shadow_y` unconditional to prevent struct layout drift across configs.
  - Moved `twin_window_style_size`, `twin_window_valid_range`, and `twin_window_dispatch` to internal API as `_twin_*`; callers updated.
  - Fixed `twin_window_create` docs: width/height are client area dimensions.

<sup>Written for commit 380a45b6894b6af741a374c5afa58a944a4d6fe1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

