### PR TITLE
Bump CI dependencies and use clang-format-20

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -2,13 +2,13 @@
 
 set -e -u -o pipefail
 
-SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(c|cxx|cpp|h|hpp)\$")
+cd "$(git rev-parse --show-toplevel)"
 
-set -x
+FAIL=0
+while IFS= read -r -d '' file; do
+    if ! clang-format-20 -- "${file}" | diff -u -p --label="${file}" --label="expected coding style" "${file}" -; then
+        FAIL=1
+    fi
+done < <(git ls-files -z '*.c' '*.h' '*.cxx' '*.cpp' '*.hpp')
 
-for file in ${SOURCES};
-do
-    clang-format-18 ${file} > expected-format
-    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
-done
-exit $(clang-format-18 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+exit ${FAIL}

--- a/.github/workflows/headless-test.yml
+++ b/.github/workflows/headless-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
       has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
               .ci/**
@@ -38,12 +38,11 @@ jobs:
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install-dependencies
       run: |
             sudo apt-get update -q -y
-            sudo apt install libsdl2-dev libjpeg-dev libpng-dev
-            sudo apt install libcairo2-dev
+            sudo apt-get install -y libsdl2-dev libjpeg-dev libpng-dev libcairo2-dev
       shell: bash
     - name: default build
       run: |
@@ -55,10 +54,13 @@ jobs:
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-18
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+            echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+            sudo apt-get update -q -y
+            sudo apt-get install -q -y clang-format-20
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ However, participation requires adherence to fundamental ground rules:
   This variant should be considered the standard for all documentation efforts.
   For instance, opt for "initialize" over "initialise" and "color" rather than "colour".
 
-Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 18 or later.
+Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 20 or later.
 
 This repository consistently contains an up-to-date `.clang-format` file with rules that match the explained ones.
 For maintaining a uniform coding style, execute the command `clang-format -i *.[ch]`.


### PR DESCRIPTION
Bump actions/checkout v4 to v6 and tj-actions/changed-files v45 to v47. Upgrade coding style check from clang-format-18 to clang-format-20, sourced from the LLVM apt repository for Ubuntu 24.04.

Rewrite check-format.sh to use git ls-files instead of find, which previously traversed .git/, externals/, and build artifacts. Remove the redundant second clang-format pass (--output-replacements-xml) that re-scanned every source file after the diff loop already caught all violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to use `clang-format-20`, bump GitHub Actions, and speed up format checks by scanning only tracked sources and avoiding redundant rescans.

- **Dependencies**
  - Bump `actions/checkout` v4 → v6 and `tj-actions/changed-files` v45 → v47.
  - Install `clang-format-20` from the LLVM apt repo on Ubuntu 24.04.
  - Update CONTRIBUTING to require `clang-format-20`.

- **Refactors**
  - Rewrite `.ci/check-format.sh` to use `git ls-files` and exit cleanly when no sources.
  - Stream `clang-format-20` to `diff` and return a single fail code; remove the extra `--output-replacements-xml` pass.

<sup>Written for commit 42b0f4db1730a0cec1c0899963ad311f056e3ee4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

