### PR TITLE
Correct pixel size in the framebuffer

### DIFF
--- a/backend/fbdev.c
+++ b/backend/fbdev.c
@@ -102,14 +102,7 @@ static inline bool twin_fbdev_is_rgb565(twin_fbdev_t *tx)
            tx->fb_var.blue.offset == 0 && tx->fb_var.blue.length == 5;
 }
 
-static inline bool twin_fbdev_is_rgb888(twin_fbdev_t *tx)
-{
-    return tx->fb_var.red.offset == 16 && tx->fb_var.red.length == 8 &&
-           tx->fb_var.green.offset == 8 && tx->fb_var.green.length == 8 &&
-           tx->fb_var.blue.offset == 0 && tx->fb_var.blue.length == 8;
-}
-
-static inline bool twin_fbdev_is_argb32(twin_fbdev_t *tx)
+static inline bool twin_fbdev_is_rgb888_or_argb32(twin_fbdev_t *tx)
 {
     return tx->fb_var.red.offset == 16 && tx->fb_var.red.length == 8 &&
            tx->fb_var.green.offset == 8 && tx->fb_var.green.length == 8 &&
@@ -147,14 +140,10 @@ static bool twin_fbdev_apply_config(twin_fbdev_t *tx)
         }
         break;
     case 24: /* RGB888 */
-        if (!twin_fbdev_is_rgb888(tx)) {
-            log_error("Invalid framebuffer format for 24 bpp");
-            return false;
-        }
-        break;
     case 32: /* ARGB32 */
-        if (!twin_fbdev_is_argb32(tx)) {
-            log_error("Invalid framebuffer format for 32 bpp");
+        if (!twin_fbdev_is_rgb888_or_argb32(tx)) {
+            log_error("Invalid framebuffer format for %u bpp",
+                      tx->fb_var.bits_per_pixel);
             return false;
         }
         break;

--- a/backend/fbdev.c
+++ b/backend/fbdev.c
@@ -45,35 +45,37 @@ typedef struct {
 } twin_fbdev_t;
 
 /* color conversion */
-#define ARGB32_TO_RGB565_PERLINE(dest, pixels, width)   \
-    do {                                                \
-        for (int i = 0; i < width; i++)                 \
-            dest[i] = ((pixels[i] & 0x00f80000) >> 8) | \
-                      ((pixels[i] & 0x0000fc00) >> 5) | \
-                      ((pixels[i] & 0x000000f8) >> 3);  \
+#define ARGB32_TO_RGB565_PERLINE(dest, pixels, width)    \
+    do {                                                 \
+        uint16_t *_dest = (uint16_t *) dest;             \
+        for (int i = 0; i < width; i++)                  \
+            _dest[i] = ((pixels[i] & 0x00f80000) >> 8) | \
+                       ((pixels[i] & 0x0000fc00) >> 5) | \
+                       ((pixels[i] & 0x000000f8) >> 3);  \
     } while (0)
 
 /* Requires validation in 24-bit per pixel environments */
 #define ARGB32_TO_RGB888_PERLINE(dest, pixels, width) \
     do {                                              \
+        uint32_t *_dest = (uint32_t *) dest;          \
         for (int i = 0; i < width; i++)               \
-            dest[i] = 0xff000000 | pixels[i];         \
+            _dest[i] = 0xff000000 | pixels[i];        \
     } while (0)
 
 #define ARGB32_TO_ARGB32_PERLINE(dest, pixels, width) \
-    memcpy(dest, pixels, width * sizeof(*dest))
+    memcpy((uint32_t *) dest, pixels, width * 4)
 
-#define FBDEV_PUT_SPAN_IMPL(bpp, op)                                     \
-    static void _twin_fbdev_put_span##bpp(                               \
-        twin_coord_t left, twin_coord_t top, twin_coord_t right,         \
-        twin_argb32_t *pixels, void *closure)                            \
-    {                                                                    \
-        uint32_t *dest;                                                  \
-        twin_fbdev_t *tx = PRIV(closure);                                \
-        off_t off = sizeof(*dest) * left + top * tx->fb_fix.line_length; \
-        dest = (uint32_t *) ((uintptr_t) tx->fb_base + off);             \
-        twin_coord_t width = right - left;                               \
-        op(dest, pixels, width);                                         \
+#define FBDEV_PUT_SPAN_IMPL(bpp, op)                                 \
+    static void _twin_fbdev_put_span##bpp(                           \
+        twin_coord_t left, twin_coord_t top, twin_coord_t right,     \
+        twin_argb32_t *pixels, void *closure)                        \
+    {                                                                \
+        uintptr_t dest;                                              \
+        twin_fbdev_t *tx = PRIV(closure);                            \
+        off_t off = (bpp / 8) * left + top * tx->fb_fix.line_length; \
+        dest = (uintptr_t) tx->fb_base + off;                        \
+        twin_coord_t width = right - left;                           \
+        op(dest, pixels, width);                                     \
     }
 
 FBDEV_PUT_SPAN_IMPL(16, ARGB32_TO_RGB565_PERLINE)

--- a/backend/fbdev.c
+++ b/backend/fbdev.c
@@ -55,11 +55,14 @@ typedef struct {
     } while (0)
 
 /* Requires validation in 24-bit per pixel environments */
-#define ARGB32_TO_RGB888_PERLINE(dest, pixels, width) \
-    do {                                              \
-        uint32_t *_dest = (uint32_t *) dest;          \
-        for (int i = 0; i < width; i++)               \
-            _dest[i] = 0xff000000 | pixels[i];        \
+#define ARGB32_TO_RGB888_PERLINE(dest, pixels, width)            \
+    do {                                                         \
+        uint8_t *_dest = (uint8_t *) dest;                       \
+        for (int i = 0; i < width; i++) {                        \
+            _dest[i * 3] = pixels[i] & 0xFF;                     \
+            _dest[i * 3 + 1] = ((pixels[i] & 0x0000FF00) >> 8);  \
+            _dest[i * 3 + 2] = ((pixels[i] & 0x00FF0000) >> 16); \
+        }                                                        \
     } while (0)
 
 #define ARGB32_TO_ARGB32_PERLINE(dest, pixels, width) \


### PR DESCRIPTION
For RGB565, 2 bytes should be used to store one pixel in the destination frame buffer. However, the _twin_fbdev_put_span16 use 4 bytes to store it, causing the render result exceeds the boundary and some black lines between columns.

This is tested on STM32F429-Discovery with Linux framebuffer backend.

The following is the screen before this change:

<img alt="image" src="https://github.com/user-attachments/assets/993e843f-445b-4155-862b-838b38f3fec6" width="100px" />

The following is the screen after this change:

<img alt="image" src="https://github.com/user-attachments/assets/901eec2f-700c-4b19-af5e-372721b75ebc" width="100px" />

It suits the screen size and the black lines disappear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix RGB565 and RGB888 writes to use the correct bytes per pixel (2 B for RGB565, 3 B for RGB888), preventing buffer overruns, misaligned writes, and black vertical lines. Verified on STM32F429-Discovery with the Linux framebuffer backend.

- **Bug Fixes**
  - Compute destination offsets using bpp; stop writing 4 B/pixel in 16bpp and 24bpp paths.
  - Update per-line conversion to use typed writes (`uint16_t` for RGB565, packed 3-byte RGB for RGB888, `uint32_t` for ARGB32) and merge duplicate format checks into one helper for 24/32 bpp.

<sup>Written for commit b08122897734fe5ed6c239bfb7aa6fd67ecbcb62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

